### PR TITLE
feature/shadcn complete migration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,7 @@
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -6,76 +10,16 @@ const nextConfig = {
   trailingSlash: false,
   images: {
     formats: ['image/avif', 'image/webp'],
-    domains: ['cdn.sanity.io'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+        port: '',
+        pathname: '/**',
+      },
+    ],
   },
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'X-DNS-Prefetch-Control',
-            value: 'on'
-          },
-          {
-            key: 'X-XSS-Protection',
-            value: '1; mode=block'
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff'
-          },
-          {
-            key: 'X-Frame-Options',
-            value: 'SAMEORIGIN'
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin'
-          },
-          {
-            key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=(self), interest-cohort=()'
-          },
-          {
-            key: 'Strict-Transport-Security',
-            value: 'max-age=31536000; includeSubDomains'
-          },
-          {
-            key: 'Content-Security-Policy',
-            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://www.google-analytics.com https://vitals.vercel-insights.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self' https://wa.me; frame-ancestors 'self'; upgrade-insecure-requests;"
-          }
-        ],
-      },
-      {
-        source: '/api/:path*',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'no-store, no-cache, must-revalidate, proxy-revalidate'
-          }
-        ]
-      },
-      {
-        source: '/(.*\\.(?:jpg|jpeg|gif|png|ico|svg|webp|avif)$)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable'
-          }
-        ]
-      },
-      {
-        source: '/(.*\\.(?:js|css|woff|woff2|ttf|otf)$)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable'
-          }
-        ]
-      }
-    ]
-  },
+  // Security headers are set centrally in src/middleware.ts
 }
 
-module.exports = nextConfig
+module.exports = withBundleAnalyzer(nextConfig)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,15 +26,78 @@
     clip: auto;
     white-space: normal;
   }
+
+  /* Animation delay utilities for loading states */
+  .animation-delay-200 {
+    animation-delay: 0.2s;
+  }
+
+  .animation-delay-400 {
+    animation-delay: 0.4s;
+  }
+}
+
+/* Base heading styles for better SEO and accessibility */
+@layer base {
+  h1 {
+    font-size: 2.25rem; /* 36px */
+    line-height: 2.5rem; /* 40px */
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-weight: 700;
+  }
+  
+  @media (min-width: 1024px) {
+    h1 {
+      font-size: 3rem; /* 48px */
+      line-height: 1;
+    }
+  }
 }
 
 /* Mobile-first base styles */
 :root {
+  /* Layout variables */
   --tap-target-size: 44px;
   --safe-area-inset-top: env(safe-area-inset-top, 0);
   --safe-area-inset-right: env(safe-area-inset-right, 0);
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0);
   --safe-area-inset-left: env(safe-area-inset-left, 0);
+  
+  /* Brand Colors */
+  --color-orange: #FF6B35;
+  --color-orange-light: #FF8F66;
+  --color-orange-dark: #E55A2B;
+  --color-teal: #2C5F5F;
+  --color-teal-light: #4A7C7C;
+  --color-teal-dark: #1A3D3D;
+  --color-cream: #FFF5EB;
+  --color-charcoal: #2C3E50;
+  --color-charcoal-light: #34495E;
+  --color-white: #FFFFFF;
+  
+  /* Semantic Colors */
+  --color-primary: var(--color-orange);
+  --color-primary-hover: var(--color-orange-dark);
+  --color-secondary: var(--color-teal);
+  --color-secondary-hover: var(--color-teal-dark);
+  --color-background: var(--color-cream);
+  --color-text: var(--color-charcoal);
+  --color-text-muted: rgba(44, 62, 80, 0.6);
+  --color-border: rgba(44, 62, 80, 0.1);
+  
+  /* External Brand Colors */
+  --color-whatsapp: #25D366;
+  --color-whatsapp-hover: #128C7E;
+  --color-facebook: #1877F2;
+  --color-twitter: #1DA1F2;
+  --color-instagram: #E4405F;
+  
+  /* Status Colors */
+  --color-success: #10B981;
+  --color-warning: #F59E0B;
+  --color-error: #EF4444;
+  --color-info: #3B82F6;
 }
 
 body {
@@ -319,5 +382,105 @@ select:focus-visible {
     /* Slightly larger on mobile for easier tapping */
     min-height: 48px;
     font-size: 1rem; /* 16px to prevent zoom on iOS */
+  }
+}
+
+/* Accordion animations for shadcn demo */
+@keyframes accordion-down {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--radix-accordion-content-height);
+  }
+}
+
+@keyframes accordion-up {
+  from {
+    height: var(--radix-accordion-content-height);
+  }
+  to {
+    height: 0;
+  }
+}
+
+.animate-accordion-down {
+  animation: accordion-down 0.2s ease-out;
+}
+
+.animate-accordion-up {
+  animation: accordion-up 0.2s ease-out;
+}
+
+/* shadcn/ui CSS Variables with Orange Jelly Theme */
+@layer base {
+  :root {
+    /* Orange Jelly Brand Colors mapped to shadcn */
+    --background: 0 0% 100%; /* white */
+    --foreground: 0 0% 17.6%; /* charcoal #2D2D2D */
+    
+    --card: 0 0% 100%; /* white */
+    --card-foreground: 0 0% 17.6%; /* charcoal */
+    
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 17.6%;
+    
+    --primary: 15 100% 60%; /* orange #FF6B35 */
+    --primary-foreground: 0 0% 100%; /* white */
+    
+    --secondary: 180 36% 28%; /* teal #2C5F5F */
+    --secondary-foreground: 0 0% 100%; /* white */
+    
+    --muted: 30 60% 96%; /* cream #FFF5EB */
+    --muted-foreground: 0 0% 45.1%;
+    
+    --accent: 30 60% 96%; /* cream */
+    --accent-foreground: 0 0% 17.6%; /* charcoal */
+    
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+    --ring: 15 100% 60%; /* orange */
+    
+    --radius: 0.5rem;
+    
+    /* Chart colors */
+    --chart-1: 15 100% 60%; /* orange */
+    --chart-2: 180 36% 28%; /* teal */
+    --chart-3: 30 60% 96%; /* cream */
+    --chart-4: 0 0% 17.6%; /* charcoal */
+    --chart-5: 15 100% 50%; /* orange-dark */
+  }
+  
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    
+    --primary: 15 100% 60%;
+    --primary-foreground: 0 0% 9%;
+    
+    --secondary: 180 36% 28%;
+    --secondary-foreground: 0 0% 98%;
+    
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
+    
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 15 100% 60%;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
     siteName: 'Orange Jelly',
     images: [
       {
-        url: `${baseUrl}/images/og/default.png`,
+        url: `${baseUrl}/opengraph-image`,
         width: 1200,
         height: 630,
         alt: "Orange Jelly — Pub marketing that works",
@@ -52,7 +52,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "How to Fill Empty Pub Tables | Pub Marketing That Works | Orange Jelly",
     description: "Struggling with empty pub tables? AI-powered marketing tools for UK pubs. Save 5+ hours weekly.",
-    images: [`${baseUrl}/images/og/default.png`],
+    images: [`${baseUrl}/opengraph-image`],
   },
   robots: {
     index: true,
@@ -63,6 +63,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: 'https://www.orangejelly.co.uk',
+  },
+  icons: {
+    icon: '/icon.png',
+    apple: '/apple-icon.png',
+    shortcut: '/icon.png',
   },
   manifest: '/manifest.json',
   other: {
@@ -78,7 +83,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Comprehensive schema.org structured data
+  // Simplified, performance-conscious schema.org structured data
   const organizationSchema = {
     "@context": "https://schema.org",
     "@type": "ProfessionalService",
@@ -94,59 +99,15 @@ export default function RootLayout({
     },
     "image": `${baseUrl}/logo.png`,
     "description": "Struggling with empty pub tables? We use AI-powered marketing strategies that transformed The Anchor from struggling to thriving. From one licensee to another.",
-    "slogan": "Fill Empty Pub Tables with Marketing That Works",
     "founder": {
       "@type": "Person",
       "@id": `${baseUrl}/#peter-pitcher`,
       "name": "Peter Pitcher",
       "jobTitle": "Founder & AI Consultant",
-      "description": "Former struggling pub owner who discovered how AI could transform pub marketing. Now helps other licensees save time and fill empty tables.",
-      "knowsAbout": ["AI Tools", "Pub Management", "Marketing Automation", "Hospitality", "Small Business"],
-      "spouse": {
-        "@type": "Person",
-        "name": "Billy Summers",
-        "jobTitle": "Operations Manager at The Anchor"
-      },
-      "worksFor": [
-        {
-          "@id": `${baseUrl}/#organization`
-        },
-        {
-          "@type": "Restaurant",
-          "name": "The Anchor",
-          "url": "https://the-anchor.pub",
-          "foundingDate": "2019-03-05",
-          "openingHoursSpecification": [
-            {
-              "@type": "OpeningHoursSpecification",
-              "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday"],
-              "opens": "16:00",
-              "closes": "22:00"
-            },
-            {
-              "@type": "OpeningHoursSpecification",
-              "dayOfWeek": ["Friday", "Saturday", "Sunday"],
-              "opens": "12:00",
-              "closes": "23:00"
-            }
-          ]
-        }
-      ]
+      "description": "Former struggling pub owner who discovered how AI could transform pub marketing. Now helps other licensees save time and fill empty tables."
     },
     "foundingDate": "2019",
-    "numberOfEmployees": {
-      "@type": "QuantitativeValue",
-      "value": 1
-    },
-    "knowsAbout": ["Pub Marketing", "AI Tools", "Social Media Automation", "Menu Design", "Customer Retention", "Event Promotion"],
-    "award": [
-      "Turned The Anchor from empty to thriving in 12 months",
-      "Improved The Anchor's food GP from 58% to 71% using AI"
-    ],
-    "areaServed": {
-      "@type": "Country",
-      "name": "United Kingdom"
-    },
+    "areaServed": "GB",
     "priceRange": "££",
     "contactPoint": {
       "@type": "ContactPoint",
@@ -157,76 +118,7 @@ export default function RootLayout({
       "contactOption": ["TollFree"],
       "areaServed": "GB"
     },
-    "sameAs": [
-      "https://the-anchor.pub"
-    ],
-    "parentOrganization": {
-      "@type": "Organization", 
-      "name": "Small UK Pub Network",
-      "description": "Independent pub owners supporting each other"
-    },
-    "memberOf": [
-      {
-        "@type": "Organization",
-        "name": "Federation of Small Businesses"
-      },
-      {
-        "@type": "Organization",
-        "name": "Greene King",
-        "url": "https://www.greeneking.co.uk",
-        "description": "We operate The Anchor as a Greene King tenant and share our AI innovations with them"
-      },
-      {
-        "@type": "Organization",
-        "name": "British Institute of Innkeeping",
-        "url": "https://www.bii.org",
-        "description": "Members of BII - Featured in BII's Autumn 2025 magazine for AI innovation"
-      }
-    ],
-    "hasOfferCatalog": {
-      "@type": "OfferCatalog",
-      "name": "Pub Recovery Services",
-      "itemListElement": [
-        {
-          "@type": "Offer",
-          "name": "Empty Pub Recovery Package",
-          "price": "499",
-          "priceCurrency": "GBP"
-        },
-        {
-          "@type": "Offer", 
-          "name": "Menu Makeover",
-          "price": "99",
-          "priceCurrency": "GBP"
-        }
-      ]
-    },
-    "makesOffer": [
-      {
-        "@type": "Offer",
-        "itemOffered": {
-          "@type": "Service",
-          "name": "Pub Marketing Services",
-          "description": "Proven marketing strategies to fill empty pub tables and increase revenue"
-        }
-      },
-      {
-        "@type": "Offer",
-        "itemOffered": {
-          "@type": "Service",
-          "name": "Social Media Marketing for Pubs",
-          "description": "Engaging social media campaigns that bring customers through your doors"
-        }
-      },
-      {
-        "@type": "Offer",
-        "itemOffered": {
-          "@type": "Service",
-          "name": "Menu Design and Marketing",
-          "description": "Create menus that sell and market them effectively to your target audience"
-        }
-      }
-    ]
+    "sameAs": ["https://the-anchor.pub"]
   };
 
   const websiteSchema = {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import PerformanceMonitor, { PreloadResources } from "@/components/PerformanceMo
 import { GoogleTagManager, GoogleTagManagerNoscript } from "@/components/GoogleTagManager";
 import { CONTACT, URLS, MESSAGES } from "@/lib/constants";
 import Button from "@/components/Button";
+import { ROICalculatorProvider } from "@/contexts/ROICalculatorContext";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -40,10 +41,10 @@ export const metadata: Metadata = {
     siteName: 'Orange Jelly',
     images: [
       {
-        url: "/logo.png",
-        width: 800,
-        height: 800,
-        alt: "Orange Jelly - AI tools for UK licensees",
+        url: `${baseUrl}/images/og/default.png`,
+        width: 1200,
+        height: 630,
+        alt: "Orange Jelly — Pub marketing that works",
       },
     ],
   },
@@ -51,6 +52,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "How to Fill Empty Pub Tables | Pub Marketing That Works | Orange Jelly",
     description: "Struggling with empty pub tables? AI-powered marketing tools for UK pubs. Save 5+ hours weekly.",
+    images: [`${baseUrl}/images/og/default.png`],
   },
   robots: {
     index: true,
@@ -284,11 +286,13 @@ export default function RootLayout({
         
         {/* Navigation only - SuperHeader removed for cleaner layout */}
         <NavigationWrapper />
-        <ErrorBoundary>
-          <main id="main-content" className="min-h-screen pt-16">
-            {children}
-          </main>
-        </ErrorBoundary>
+        <ROICalculatorProvider>
+          <ErrorBoundary>
+            <main id="main-content" className="min-h-screen pt-16">
+              {children}
+            </main>
+          </ErrorBoundary>
+        </ROICalculatorProvider>
         <FooterWrapper />
         <PerformanceMonitor />
         
@@ -314,7 +318,7 @@ export default function RootLayout({
               href={URLS.whatsapp(MESSAGES.whatsapp.services)}
               variant="custom"
               className="block bg-green-500 text-white p-4 rounded-full shadow-lg hover:shadow-xl transition-all hover:scale-110 relative overflow-hidden"
-              ariaLabel={`Contact us on WhatsApp at ${CONTACT.phone}`}
+              aria-label={`Contact us on WhatsApp at ${CONTACT.phone}`}
               external={true}
             >
               {/* Orange accent */}

--- a/src/app/licensees-guide/[slug]/page.tsx
+++ b/src/app/licensees-guide/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Hero from '@/components/Hero';
@@ -7,7 +8,10 @@ import { getContentPostBySlug, getContentPosts } from '@/lib/content-source';
 import { BlogPostingSchema } from '@/components/BlogPostingSchema';
 import { FAQSchema } from '@/components/StructuredData';
 import EnhancedBlogSchema from '@/components/blog/EnhancedBlogSchema';
+import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd';
 import { breadcrumbPaths } from '@/components/Breadcrumb';
+import { AsyncErrorBoundary } from '@/components/ErrorBoundary';
+import { PageLoading } from '@/components/Loading';
 
 interface BlogPostPageProps {
   params: {
@@ -52,86 +56,109 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
   };
 }
 
-export default async function BlogPostPage({ params }: BlogPostPageProps) {
-  const post = await getContentPostBySlug(params.slug);
+// Async component that fetches data
+async function BlogPostPageData({ params }: { params: { slug: string } }) {
+  try {
+    const post = await getContentPostBySlug(params.slug);
 
-  if (!post) {
-    notFound();
-  }
+    if (!post) {
+      notFound();
+    }
 
-  // Get related posts (same category, different post)
-  const allPosts = await getContentPosts();
-  const relatedPosts = allPosts
-    .filter(p => p.category === post.category && p.slug !== post.slug)
-    .slice(0, 3);
+    // Get related posts (same category, different post)
+    const allPosts = await getContentPosts();
+    const relatedPosts = allPosts
+      .filter(p => p.category === post.category && p.slug !== post.slug)
+      .slice(0, 3);
 
-  // Extract FAQs from content if they exist (only for markdown content)
-  let faqs: Array<{ question: string; answer: string }> = [];
-  
-  // Use FAQs from Sanity if available, otherwise extract from markdown
-  if ((post as any).faqs && (post as any).faqs.length > 0) {
-    faqs = (post as any).faqs;
-  } else if (!post.isPortableText && typeof post.content === 'string') {
-    const faqPattern = /##\s*FAQs?\s*\n([\s\S]*?)(?=\n##|$)/i;
-    const faqMatch = post.content.match(faqPattern);
+    // Extract FAQs from content if they exist (only for markdown content)
+    let faqs: Array<{ question: string; answer: string }> = [];
     
-    if (faqMatch) {
-      const faqContent = faqMatch[1];
-      const faqItemPattern = /###\s*(.+?)\n([\s\S]*?)(?=\n###|$)/g;
-      let match;
-      while ((match = faqItemPattern.exec(faqContent)) !== null) {
-        faqs.push({
-          question: match[1].trim(),
-          answer: match[2].trim()
-        });
+    // Use FAQs from Sanity if available, otherwise extract from markdown
+    if ((post as any).faqs && (post as any).faqs.length > 0) {
+      faqs = (post as any).faqs;
+    } else if (!post.isPortableText && typeof post.content === 'string') {
+      const faqPattern = /##\s*FAQs?\s*\n([\s\S]*?)(?=\n##|$)/i;
+      const faqMatch = post.content.match(faqPattern);
+      
+      if (faqMatch) {
+        const faqContent = faqMatch[1];
+        const faqItemPattern = /###\s*(.+?)\n([\s\S]*?)(?=\n###|$)/g;
+        let match;
+        while ((match = faqItemPattern.exec(faqContent)) !== null) {
+          faqs.push({
+            question: match[1].trim(),
+            answer: match[2].trim()
+          });
+        }
       }
     }
-  }
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.orangejelly.co.uk';
-  
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.orangejelly.co.uk';
+    
+    return (
+      <>
+        <EnhancedBlogSchema 
+          post={{
+            ...post,
+            faqs,
+            quickAnswer: (post as any).quickAnswer,
+            voiceSearchQueries: (post as any).voiceSearchQueries,
+            localSEO: (post as any).localSEO
+          }}
+          baseUrl={baseUrl}
+        />
+        <BreadcrumbJsonLd
+          items={[
+            { name: 'Home', url: '/' },
+            { name: "The Licensee's Guide", url: '/licensees-guide' },
+            { name: post.title, url: `/licensees-guide/${post.slug}` },
+          ]}
+        />
+        <BlogPostingSchema
+          title={post.title}
+          description={post.excerpt}
+          content={typeof post.content === 'string' ? post.content : ''}
+          author={{
+            name: post.author?.name || 'Peter Pitcher',
+            url: '/about'
+          }}
+          datePublished={post.publishedDate}
+          dateModified={post.updatedDate}
+          image={typeof post.featuredImage === 'string' ? post.featuredImage : (post.featuredImage as any)?.src}
+          url={`/licensees-guide/${post.slug}`}
+          keywords={post.tags}
+          speakableSections={['.prose h2', '.prose h3', '.prose > p:first-of-type', '.quick-answer']}
+        />
+        {faqs.length > 0 && <FAQSchema faqs={faqs} />}
+        <Hero
+          title={post.title}
+          subtitle={post.excerpt}
+          showCTA={false}
+          breadcrumbs={[
+            ...breadcrumbPaths.licenseesGuide,
+            { label: post.title }
+          ]}
+        />
+        <Section background="white">
+          <div className="max-w-6xl mx-auto">
+            <BlogPostClient post={post} relatedPosts={relatedPosts} />
+          </div>
+        </Section>
+      </>
+    );
+  } catch (error) {
+    console.error('Error fetching blog post data:', error);
+    throw new Error('Failed to load blog post content. Please try again.');
+  }
+}
+
+export default function BlogPostPage({ params }: BlogPostPageProps) {
   return (
-    <>
-      <EnhancedBlogSchema 
-        post={{
-          ...post,
-          faqs,
-          quickAnswer: (post as any).quickAnswer,
-          voiceSearchQueries: (post as any).voiceSearchQueries,
-          localSEO: (post as any).localSEO
-        }}
-        baseUrl={baseUrl}
-      />
-      <BlogPostingSchema
-        title={post.title}
-        description={post.excerpt}
-        content={typeof post.content === 'string' ? post.content : ''}
-        author={{
-          name: post.author?.name || 'Peter Pitcher',
-          url: '/about'
-        }}
-        datePublished={post.publishedDate}
-        dateModified={post.updatedDate}
-        image={typeof post.featuredImage === 'string' ? post.featuredImage : (post.featuredImage as any)?.src}
-        url={`/licensees-guide/${post.slug}`}
-        keywords={post.tags}
-        speakableSections={['.prose h2', '.prose h3', '.prose > p:first-of-type', '.quick-answer']}
-      />
-      {faqs.length > 0 && <FAQSchema faqs={faqs} />}
-      <Hero
-        title={post.title}
-        subtitle={post.excerpt}
-        showCTA={false}
-        breadcrumbs={[
-          ...breadcrumbPaths.licenseesGuide,
-          { label: post.title }
-        ]}
-      />
-      <Section background="white">
-        <div className="max-w-6xl mx-auto">
-          <BlogPostClient post={post} relatedPosts={relatedPosts} />
-        </div>
-      </Section>
-    </>
+    <AsyncErrorBoundary>
+      <Suspense fallback={<PageLoading message="Loading blog post..." />}>
+        <BlogPostPageData params={params} />
+      </Suspense>
+    </AsyncErrorBoundary>
   );
 }

--- a/src/app/licensees-guide/category/[category]/page.tsx
+++ b/src/app/licensees-guide/category/[category]/page.tsx
@@ -7,6 +7,7 @@ import CategoryList from '@/components/blog/CategoryList';
 import { getAllPosts, getCategories } from '@/lib/blog-md';
 import { CollectionPageSchema } from '@/components/CollectionPageSchema';
 import { breadcrumbPaths } from '@/components/Breadcrumb';
+import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd';
 
 interface CategoryPageProps {
   params: {
@@ -82,6 +83,13 @@ export default function CategoryPage({ params }: CategoryPageProps) {
           { name: 'Home', url: '/' },
           { name: "The Licensee's Guide", url: '/licensees-guide' },
           { name: categoryTitle, url: `/licensees-guide/category/${params.category}` }
+        ]}
+      />
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', url: '/' },
+          { name: "The Licensee's Guide", url: '/licensees-guide' },
+          { name: categoryTitle, url: `/licensees-guide/category/${params.category}` },
         ]}
       />
       <Hero

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,67 @@
+import { ImageResponse } from 'next/og'
+
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+export default function OGImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#FFF5EB',
+          fontFamily: 'Inter, system-ui, sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 32,
+            padding: 48,
+            border: '8px solid #FF6B35',
+            borderRadius: 24,
+          }}
+        >
+          <div
+            style={{
+              background: '#FF6B35',
+              color: '#FFFFFF',
+              fontSize: 72,
+              fontWeight: 800,
+              padding: '24px 32px',
+              borderRadius: 16,
+              lineHeight: 1,
+            }}
+          >
+            OJ
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ fontSize: 56, color: '#2D2D2D', fontWeight: 800 }}>
+              Orange Jelly
+            </div>
+            <div style={{ fontSize: 36, color: '#2C5F5F', fontWeight: 600 }}>
+              Pub marketing that works
+            </div>
+            <div style={{ fontSize: 28, color: '#2D2D2D' }}>
+              Fill empty pub tables. Save 5+ hours weekly.
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}
+
+

--- a/src/components/BlogPostingSchema.tsx
+++ b/src/components/BlogPostingSchema.tsx
@@ -28,6 +28,8 @@ export function BlogPostingSchema({
   keywords = [],
   speakableSections = []
 }: BlogPostingSchemaProps) {
+  const isAbsolute = (u: string) => /^https?:\/\//i.test(u);
+  const site = 'https://www.orangejelly.co.uk';
   const schema = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -35,7 +37,7 @@ export function BlogPostingSchema({
     "description": description,
     "image": {
       "@type": "ImageObject",
-      "url": `https://www.orangejelly.co.uk${image}`,
+      "url": isAbsolute(image) ? image : `${site}${image}`,
       "width": 1200,
       "height": 630
     },
@@ -44,7 +46,7 @@ export function BlogPostingSchema({
     "author": {
       "@type": "Person",
       "name": author.name,
-      ...(author.url && { "url": `https://www.orangejelly.co.uk${author.url}` })
+      ...(author.url && { "url": isAbsolute(author.url) ? author.url : `${site}${author.url}` })
     },
     "publisher": {
       "@type": "Organization",
@@ -58,7 +60,7 @@ export function BlogPostingSchema({
     },
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": `https://www.orangejelly.co.uk${url}`
+      "@id": isAbsolute(url) ? url : `${site}${url}`
     },
     "articleBody": content,
     ...(keywords.length > 0 && { "keywords": keywords.join(", ") }),

--- a/src/components/PerformanceMonitor.tsx
+++ b/src/components/PerformanceMonitor.tsx
@@ -51,10 +51,14 @@ export function PreloadResources() {
         type="image/png"
       />
       
-      {/* DNS prefetch for external resources */}
+      {/* DNS prefetch / preconnect for external resources used by analytics */}
       <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+      <link rel="preconnect" href="https://www.google-analytics.com" crossOrigin="anonymous" />
+      <link rel="preconnect" href="https://region1.google-analytics.com" crossOrigin="anonymous" />
+      <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
+      <link rel="preconnect" href="https://www.clarity.ms" crossOrigin="anonymous" />
     </>
   );
 }

--- a/src/components/seo/BreadcrumbJsonLd.tsx
+++ b/src/components/seo/BreadcrumbJsonLd.tsx
@@ -1,0 +1,28 @@
+interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export function BreadcrumbJsonLd({ items }: { items: BreadcrumbItem[] }) {
+  const isAbsolute = (u: string) => /^https?:\/\//i.test(u);
+  const site = 'https://www.orangejelly.co.uk';
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: isAbsolute(item.url) ? item.url : `${site}${item.url}`,
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
+

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -18,7 +18,7 @@ export function generateMetadata({
   description,
   path,
   keywords,
-  ogImage = '/logo.png',
+  ogImage = '/images/og/default.png',
   noIndex = false,
   ogType = 'website',
   publishedTime,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,10 +5,11 @@ export function middleware(request: NextRequest) {
   const response = NextResponse.next();
   
   // Security headers
-  response.headers.set('X-Frame-Options', 'DENY');
+  response.headers.set('X-Frame-Options', 'SAMEORIGIN');
   response.headers.set('X-Content-Type-Options', 'nosniff');
-  response.headers.set('Referrer-Policy', 'origin-when-cross-origin');
-  response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  // Note: FLoC is obsolete; use browsing-topics to opt-out of Topics API
+  response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), browsing-topics=()');
   
   // Strict Transport Security (HSTS) - only on production
   if (process.env.NODE_ENV === 'production') {
@@ -21,14 +22,22 @@ export function middleware(request: NextRequest) {
   // Basic Content Security Policy
   response.headers.set(
     'Content-Security-Policy',
-    "default-src 'self'; " +
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://www.clarity.ms https://scripts.clarity.ms; " +
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-    "font-src 'self' https://fonts.gstatic.com; " +
-    "img-src 'self' data: https: blob:; " +
-    "connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://vitals.vercel-insights.com https://www.clarity.ms https://h.clarity.ms; " +
-    "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; " +
-    "object-src 'none';"
+    [
+      "default-src 'self'",
+      // Use next/script and nonces in future to remove 'unsafe-inline'. Kept temporarily for GTM bootstrap.
+      "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://www.clarity.ms https://scripts.clarity.ms",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "font-src 'self' https://fonts.gstatic.com data:",
+      "img-src 'self' data: blob: https:",
+      "connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://vitals.vercel-insights.com https://www.clarity.ms https://h.clarity.ms https://j.clarity.ms https://9brdfanc.api.sanity.io https://cdn.sanity.io",
+      "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+      "media-src 'self' https:",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self' https://wa.me",
+      "frame-ancestors 'self'",
+      'upgrade-insecure-requests'
+    ].join('; ')
   );
   
   return response;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,41 +1,46 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
+    darkMode: ["class"],
+    content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {
-      colors: {
-        orange: {
-          DEFAULT: '#FF6B35',
-          light: '#FF8555',
-          dark: '#E55125',
-        },
-        teal: {
-          DEFAULT: '#2C5F5F',
-          light: '#3C6F6F',
-          dark: '#1C4F4F',
-        },
-        cream: {
-          DEFAULT: '#FFF5EB',
-          light: '#FFFBF5',
-          dark: '#FFF0E0',
-        },
-        charcoal: {
-          DEFAULT: '#2D2D2D',
-          light: '#3D3D3D',
-          dark: '#1D1D1D',
-        }
-      },
-      fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
-      },
-      backgroundImage: {
-        'gradient-stripe': 'repeating-linear-gradient(45deg, transparent, transparent 35px, rgba(255,255,255,.1) 35px, rgba(255,255,255,.1) 70px)'
-      },
-      typography: (theme) => ({
+  	extend: {
+  		colors: {
+  			orange: {
+  				DEFAULT: '#FF6B35',
+  				light: '#FF8555',
+  				dark: '#E55125'
+  			},
+  			teal: {
+  				DEFAULT: '#2C5F5F',
+  				light: '#3C6F6F',
+  				dark: '#1C4F4F'
+  			},
+  			cream: {
+  				DEFAULT: '#FFF5EB',
+  				light: '#FFFBF5',
+  				dark: '#FFF0E0'
+  			},
+  			charcoal: {
+  				DEFAULT: '#2D2D2D',
+  				light: '#3D3D3D',
+  				dark: '#1D1D1D'
+  			}
+  		},
+  		fontFamily: {
+  			sans: [
+  				'Inter',
+  				'system-ui',
+  				'sans-serif'
+  			]
+  		},
+  		backgroundImage: {
+  			'gradient-stripe': 'repeating-linear-gradient(45deg, transparent, transparent 35px, rgba(255,255,255,.1) 35px, rgba(255,255,255,.1) 70px)'
+  		},
+  		typography: (theme) => ({
         DEFAULT: {
           css: {
             color: theme('colors.charcoal.DEFAULT'),
@@ -61,10 +66,12 @@ module.exports = {
             },
             a: {
               color: theme('colors.orange.DEFAULT'),
+              textDecoration: 'underline',
+              textUnderlineOffset: '2px',
               '&:hover': {
                 color: theme('colors.orange.dark'),
+                textDecorationThickness: '2px',
               },
-              textDecoration: 'none',
             },
             blockquote: {
               borderLeftColor: theme('colors.orange.DEFAULT'),
@@ -100,7 +107,29 @@ module.exports = {
           },
         },
       }),
-    },
+  		keyframes: {
+  			'accordion-down': {
+  				from: {
+  					height: '0'
+  				},
+  				to: {
+  					height: 'var(--radix-accordion-content-height)'
+  				}
+  			},
+  			'accordion-up': {
+  				from: {
+  					height: 'var(--radix-accordion-content-height)'
+  				},
+  				to: {
+  					height: '0'
+  				}
+  			}
+  		},
+  		animation: {
+  			'accordion-down': 'accordion-down 0.2s ease-out',
+  			'accordion-up': 'accordion-up 0.2s ease-out'
+  		}
+  	}
   },
   plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
- **fix(headers): consolidate to middleware, align policies, update Permissions-Policy; remove next.config headers (Closes #15)**
- **fix(sitemap): remove fragment URLs for services; only include canonical pages (Closes #16)**
- **feat(seo): standardise OG/Twitter defaults to 1200x630; harden BlogPosting JSON-LD URL handling (Closes #17, Closes #18)**
- **feat(a11y): improve link affordance in prose with underlines and stronger hover (Closes #19)**
- **perf: add preconnects for analytics domains in head (Closes #20)**
- **chore(css): minor housekeeping around focus styles (no functional change)**
- **feat(seo): add per-page BreadcrumbList JSON-LD for articles and categories (Closes #25)**
- **perf(seo): simplify root JSON-LD; set OG/Twitter images to dynamic opengraph-image; add icons metadata (Closes #22)**
- **feat(og): add dynamic 1200x630 OpenGraph image endpoint**
- **chore: small follow-ups to headers and icon metadata**
