### PR TITLE
fix(ui): align all content to a single max-w-4xl width

### DIFF
--- a/src/app/licensees-guide/[slug]/page.tsx
+++ b/src/app/licensees-guide/[slug]/page.tsx
@@ -736,7 +736,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           />
         )}
         <Section background="white">
-          <div className="max-w-6xl mx-auto">
+          <div className="max-w-4xl mx-auto">
             <BlogPostClient
               post={postWithFaqs}
               relatedPosts={isHub ? [] : relatedPosts}

--- a/src/app/licensees-guide/category/[category]/page.tsx
+++ b/src/app/licensees-guide/category/[category]/page.tsx
@@ -136,7 +136,7 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
       />
 
       <Section background="white">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-12">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-12">
           {/* Category Navigation */}
           <div className="mb-12">
             <CategoryList

--- a/src/app/licensees-guide/page.tsx
+++ b/src/app/licensees-guide/page.tsx
@@ -199,7 +199,7 @@ export default async function LicenseesGuidePage() {
           showCTA={false}
         />
         <Section background="white">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 py-12">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 py-12">
             <Text className="text-red-600 text-center">
               Error loading blog posts. Please try refreshing the page.
             </Text>
@@ -242,9 +242,9 @@ export default async function LicenseesGuidePage() {
       <SeasonalPlaybooksBand background="cream" />
 
       <Section background="white">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-12">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-12">
           {/* Lead paragraph */}
-          <Text size="lg" align="center" className="max-w-3xl mx-auto mb-8 text-charcoal/70">
+          <Text size="lg" align="center" className="max-w-4xl mx-auto mb-8 text-charcoal/70">
             Essential guides for modern pub management, with ideas you can adapt for restaurants and
             bars. From filling empty venues to competing with chains, discover practical advice that
             actually works.
@@ -273,7 +273,7 @@ export default async function LicenseesGuidePage() {
           </div>
 
           {/* Introduction */}
-          <div className="prose prose-lg max-w-3xl mx-auto mb-12">
+          <div className="prose prose-lg max-w-4xl mx-auto mb-12">
             <Text className="mb-4">
               Every guide in this collection comes from real experience at The Anchor in Stanwell
               Moor. We've tested these strategies firsthand, measuring their impact on our bottom

--- a/src/components/SeasonalPlaybooksBand.tsx
+++ b/src/components/SeasonalPlaybooksBand.tsx
@@ -37,45 +37,47 @@ export default function SeasonalPlaybooksBand({
 
   return (
     <Section background={background}>
-      <div className="text-center mb-8">
-        <Heading level={2} align="center" className="mb-3">
-          {heading}
-        </Heading>
-        <Text size="lg" align="center" className="max-w-2xl mx-auto text-charcoal/70">
-          {subtitle}
-        </Text>
-      </div>
-      <Grid columns={{ default: 1, sm: 2, lg: 3 }} gap="medium">
-        {SEASON_HUBS.map((hub) => {
-          const inSeason = highlightInSeason && isHubInSeason(hub);
-          return (
-            <Card key={hub.hubSlug} variant="bordered" asChild>
-              <Link
-                href={`/licensees-guide/${hub.hubSlug}`}
-                color="inherit"
-                className="group block h-full"
-              >
-                <span className="flex flex-wrap items-center gap-2 mb-3">
-                  <span className="inline-block px-3 py-1 rounded-full text-xs font-semibold tracking-wide uppercase bg-orange/10 text-orange">
-                    {hub.dateRangeLabel}
-                  </span>
-                  {inSeason && (
-                    <span className="inline-block px-3 py-1 rounded-full text-xs font-semibold tracking-wide uppercase bg-teal text-white">
-                      This season
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-8">
+          <Heading level={2} align="center" className="mb-3">
+            {heading}
+          </Heading>
+          <Text size="lg" align="center" className="max-w-2xl mx-auto text-charcoal/70">
+            {subtitle}
+          </Text>
+        </div>
+        <Grid columns={{ default: 1, sm: 2, lg: 3 }} gap="medium">
+          {SEASON_HUBS.map((hub) => {
+            const inSeason = highlightInSeason && isHubInSeason(hub);
+            return (
+              <Card key={hub.hubSlug} variant="bordered" asChild>
+                <Link
+                  href={`/licensees-guide/${hub.hubSlug}`}
+                  color="inherit"
+                  className="group block h-full"
+                >
+                  <span className="flex flex-wrap items-center gap-2 mb-3">
+                    <span className="inline-block px-3 py-1 rounded-full text-xs font-semibold tracking-wide uppercase bg-orange/10 text-orange">
+                      {hub.dateRangeLabel}
                     </span>
-                  )}
-                </span>
-                <Heading level={3} className="mb-2 group-hover:text-orange transition-colors">
-                  {hub.label}
-                </Heading>
-                <Text color="muted">
-                  {hub.featuredGuides.length} practical guides for the {hub.season} season.
-                </Text>
-              </Link>
-            </Card>
-          );
-        })}
-      </Grid>
+                    {inSeason && (
+                      <span className="inline-block px-3 py-1 rounded-full text-xs font-semibold tracking-wide uppercase bg-teal text-white">
+                        This season
+                      </span>
+                    )}
+                  </span>
+                  <Heading level={3} className="mb-2 group-hover:text-orange transition-colors">
+                    {hub.label}
+                  </Heading>
+                  <Text color="muted">
+                    {hub.featuredGuides.length} practical guides for the {hub.season} season.
+                  </Text>
+                </Link>
+              </Card>
+            );
+          })}
+        </Grid>
+      </div>
     </Section>
   );
 }

--- a/src/components/blog/BlogCategoryHero.tsx
+++ b/src/components/blog/BlogCategoryHero.tsx
@@ -37,7 +37,7 @@ export default function BlogCategoryHero({
       />
 
       {/* Content */}
-      <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 py-12 md:py-20">
+      <div className="relative z-10 max-w-4xl mx-auto px-4 sm:px-6 py-12 md:py-20">
         {/* Breadcrumbs — light variant for dark backgrounds */}
         {breadcrumbs && breadcrumbs.length > 0 && (
           <div className="mb-6">

--- a/src/components/blog/BlogPost.tsx
+++ b/src/components/blog/BlogPost.tsx
@@ -143,9 +143,9 @@ export default function BlogPost({ post, relatedPosts = [], adjacentPosts }: Blo
       {/* Sticky CTA */}
       <StickyCTA />
 
-      <article id="blog-article" className="max-w-3xl mx-auto">
+      <article id="blog-article" className="max-w-4xl mx-auto">
         {/* Post metadata */}
-        <header className="mb-8 max-w-3xl mx-auto">
+        <header className="mb-8 max-w-4xl mx-auto">
           <div className="flex flex-wrap items-center gap-4 text-sm text-charcoal/60 mb-6">
             <Button
               href={`/licensees-guide/category/${typeof post.category === 'string' ? post.category : post.category.slug}`}

--- a/src/components/blog/SeasonalCalendar.tsx
+++ b/src/components/blog/SeasonalCalendar.tsx
@@ -40,7 +40,7 @@ export default function SeasonalCalendar({
 
   return (
     <section data-season={season} aria-label={heading} className="py-12 md:py-16" style={tintStyle}>
-      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6">
         <div className="mb-8 max-w-3xl">
           <Heading level={2} className="mb-2">
             {heading}

--- a/src/components/blog/SeasonalHubHero.tsx
+++ b/src/components/blog/SeasonalHubHero.tsx
@@ -46,7 +46,7 @@ export default function SeasonalHubHero({
         aria-hidden="true"
       />
 
-      <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 py-12 md:py-20">
+      <div className="relative z-10 max-w-4xl mx-auto px-4 sm:px-6 py-12 md:py-20">
         {breadcrumbs && breadcrumbs.length > 0 && (
           <div className="mb-6">
             <Breadcrumb items={breadcrumbs} variant="light" />

--- a/src/components/blog/SeriesHubGrid.tsx
+++ b/src/components/blog/SeriesHubGrid.tsx
@@ -69,17 +69,19 @@ export default function SeriesHubGrid({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
       />
-      <Heading level={2} className="mb-2">
-        {heading}
-      </Heading>
-      <Text color="muted" className="mb-8">
-        {subtitle}
-      </Text>
-      <Grid columns={{ default: 1, sm: 2, lg: 3 }} gap="medium">
-        {posts.map((post) => (
-          <BlogPostCard key={post.slug} post={post} />
-        ))}
-      </Grid>
+      <div className="max-w-4xl mx-auto">
+        <Heading level={2} className="mb-2">
+          {heading}
+        </Heading>
+        <Text color="muted" className="mb-8">
+          {subtitle}
+        </Text>
+        <Grid columns={{ default: 1, sm: 2, lg: 3 }} gap="medium">
+          {posts.map((post) => (
+            <BlogPostCard key={post.slug} post={post} />
+          ))}
+        </Grid>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## What changed
Standardises every content block — both heroes (seasonal hub + regular/category), the "At a glance" calendar, the spoke grids, the seasonal playbooks band, the article body (Quick Answer, prose, FAQs, CTA, author bio), the guides index and category pages — to a single **`max-w-4xl`** content width, so text and card grids share the same left/right edges. Full-bleed section backgrounds are preserved; card grids stay 3-wide.

## Why
Content was rendering at five different widths (`3xl`/`4xl`/`5xl`/`6xl` + unconstrained grids). On hub pages this meant the calendar cards sat wider than the article text and nothing lined up. A single content width fixes the mismatch across every content template, not just one component.

## Testing done
- [x] Lint EXIT 0 (incl. growth-language + British-English checks)
- [x] Tests 67/67 passed (Vitest)
- [x] Build EXIT 0; `tsc --noEmit` clean
- [x] Manually verified on localhost — a seasonal hub page and a regular post; hero, calendar, prose and card grids now align to the same edges

## Complexity score
S — presentational container-width changes only; no logic, schema, or data changes.

## Breaking changes
None.

## Migration risk
None — purely presentational and fully revertable.
