### PR TITLE
feat: autumn cluster keyword retarget + Oktoberfest + SEO fixes

### DIFF
--- a/content/blog/autumn-pub-event-ideas.md
+++ b/content/blog/autumn-pub-event-ideas.md
@@ -2,6 +2,7 @@
 title: "Autumn Pub Event Ideas: The Playbook for Sept–Nov"
 slug: "autumn-pub-event-ideas"
 publishedDate: 2026-05-25
+updatedDate: 2026-05-31
 excerpt: "The autumn pub event ideas that actually fill tables: cask, low and no, wine, Halloween, rugby and gifting — the September-to-November moments and how to run them."
 quickAnswer: "The best autumn pub event ideas are Cask Ale Week, a low-and-no push for Sober October, a wine tasting night, Halloween and Bonfire, November rugby, and early Christmas gifting. Pick two or three that fit your pub, plan them early, and take bookings before guests drift into Christmas mode."
 author: "Peter Pitcher"
@@ -63,13 +64,15 @@ At The Anchor in Stanwell Moor, the lesson is always the same: you don't need to
 
 September is about easing people back into midweek habits as the nights draw in. **Cask Ale Week (expected 17–27 September)** is the easy excuse to get regulars trying something new and casual drinkers asking questions at the bar — one featured cask, a plain-English tasting note, and a confident staff recommendation go a long way. The full ten-day plan is in our [Cask Ale Week guide](/licensees-guide/cask-ale-week-pub-guide).
 
-The same week, **Macmillan's World's Biggest Coffee Morning (Friday 25 September)** fills a quiet daytime and does some good — coffee, cake, and a reason for the community to gather before the lunch rush.
+The biggest September opportunity, though, lands right at the end of the month: **Oktoberfest** runs into the last weekend, and it's the easiest themed night to make a proper noise about — steins, a stack of bratwurst, a bit of oompah and a German beer or two on the bar. Our [Oktoberfest pub guide](/licensees-guide/oktoberfest-pub-guide) has the whole thing, from the food to the playlist.
+
+The same week, **Macmillan's World's Biggest Coffee Morning (Friday 25 September)** fills a quiet daytime and does some good — coffee, cake, and a reason for the community to gather before the lunch rush. Our [coffee morning guide for pubs](/licensees-guide/macmillan-coffee-morning-pub-guide) has the run-sheet, the raffle and how to make a daytime pay.
 
 ## October: low/no, wine and the spirit days
 
 **Sober October** is not a threat to your wet sales — it's a chance to sell to drivers, moderators, midweek visitors and anyone who wants to stay longer without another full-strength round. A small, visible low/no range earns its place all year. See [Sober October: low and no drinks that sell](/licensees-guide/sober-october-low-no-alcohol-pubs).
 
-October is also the right month to **relaunch your wine list** before party season — make it easy to choose, put a staff pick on social, and test a tasting night. Our guide to [running a wine tasting evening](/licensees-guide/wine-tasting-evenings-for-pubs) keeps it simple. Build in the drinks days as light hooks too: **National Vodka Day (4 Oct)**, **Gin & Tonic Day (19 Oct)** and **Champagne Weekend (23–24 Oct)**.
+October is also the right month to **relaunch your wine list** before party season — make it easy to choose, put a staff pick on social, and test a tasting night. Our guide to [running a wine tasting evening](/licensees-guide/wine-tasting-evenings-for-pubs) keeps it simple. Build in the [national drinks days](/licensees-guide/national-drinks-days-pub-guide) as light hooks too — **National Vodka Day (4 Oct)**, **Gin & Tonic Day (19 Oct)** and **Champagne Weekend (23–24 Oct)** — each one a single featured serve that lifts spend without becoming a whole event.
 
 ## Halloween and Bonfire
 

--- a/content/blog/autumn-pub-event-ideas.md
+++ b/content/blog/autumn-pub-event-ideas.md
@@ -1,9 +1,9 @@
 ---
-title: "The Autumn Pub Playbook: How to Fill Your Pub from September to November"
+title: "Autumn Pub Event Ideas: The Playbook for Sept–Nov"
 slug: "autumn-pub-event-ideas"
 publishedDate: 2026-05-25
-excerpt: "A practical autumn plan for pubs: cask, low and no, wine, Halloween, rugby and gifting — the September-to-November moments that fill tables, and how to run them."
-quickAnswer: "The autumn moments that reliably fill pubs are Cask Ale Week, Sober October's low-and-no range, wine tasting nights, Halloween and Bonfire, November rugby and early Christmas gifting. Pick two or three that fit your pub, plan them early, and take bookings before guests drift into Christmas mode."
+excerpt: "The autumn pub event ideas that actually fill tables: cask, low and no, wine, Halloween, rugby and gifting — the September-to-November moments and how to run them."
+quickAnswer: "The best autumn pub event ideas are Cask Ale Week, a low-and-no push for Sober October, a wine tasting night, Halloween and Bonfire, November rugby, and early Christmas gifting. Pick two or three that fit your pub, plan them early, and take bookings before guests drift into Christmas mode."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/autumn-pub-event-ideas.svg"
@@ -16,23 +16,25 @@ seasons:
   - autumn
 occasions: []
 status: "published"
-metaDescription: "A practical autumn plan for pubs — cask, low/no, wine, Halloween, rugby and gifting. The September-to-November moments that fill tables and how to run them."
+metaDescription: "Autumn pub event ideas that fill tables — cask, low/no, wine, Halloween, rugby and gifting. A September-to-November plan and how to run each one."
 keywords:
-  - "autumn pub events"
-  - "autumn pub ideas"
-  - "autumn pub promotions"
-  - "what to do in a pub in autumn"
+  - "pub event ideas"
+  - "autumn pub event ideas"
+  - "pub entertainment ideas"
+  - "bar event ideas"
+  - "pub promotion ideas"
+  - "seasonal pub marketing ideas"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
-  - "what events can a pub run in autumn"
+  - "what are the best autumn pub event ideas"
+  - "pub event ideas to fill a quiet midweek"
   - "how do I get my pub busy in November"
-  - "autumn pub promotion ideas"
   - "what dates matter for pubs in autumn"
 faqs:
-  - question: "What are the best autumn events for a pub?"
-    answer: "The reliable ones are Cask Ale Week in September, a low-and-no push for Sober October, a wine tasting night, Halloween and Bonfire Night, November rugby, and early Christmas gifting. Pick the two or three that fit your pub rather than trying to run all of them."
+  - question: "What are the best autumn pub event ideas?"
+    answer: "The reliable autumn pub event ideas are Cask Ale Week in September, a low-and-no push for Sober October, a wine tasting night, Halloween and Bonfire Night, November rugby, and early Christmas gifting. Pick the two or three that fit your pub rather than trying to run all of them."
   - question: "When should I start planning autumn?"
     answer: "Now. The moments run from mid-September to the end of November, and the pubs that win take bookings weeks ahead. Block the dates, brief the team, and open bookings three to four weeks before each event."
   - question: "How do I get my pub busy in November?"
@@ -49,9 +51,9 @@ schema:
   "@type": "Article"
 ---
 
-# The Autumn Pub Playbook: How to Fill Your Pub from September to November
+# Autumn Pub Event Ideas: The Autumn Pub Playbook for September to November
 
-Autumn isn't one long season. It's a chain of reasons to visit — a pint of cask in September, a coffee for a good cause, a brilliant alcohol-free round in October, a Halloween night that fills the diary, a new glass off the wine list, a pub full of rugby shirts in November.
+The best autumn pub event ideas aren't one long season — they're a chain of reasons to visit. A pint of cask in September, a coffee for a good cause, a brilliant alcohol-free round in October, a Halloween night that fills the diary, a new glass off the wine list, a pub full of rugby shirts in November.
 
 At The Anchor in Stanwell Moor, the lesson is always the same: you don't need to do everything. Pick two or three of the moments below that suit your pub, plan them early, and give people a reason to book before everyone drifts into Christmas mode. This is the overview — each section links to the full how-to.
 
@@ -59,7 +61,7 @@ At The Anchor in Stanwell Moor, the lesson is always the same: you don't need to
 
 ## September: cask and community
 
-September is about easing people back into midweek habits as the nights draw in. **Cask Ale Week (17–27 September)** is the easy excuse to get regulars trying something new and casual drinkers asking questions at the bar — one featured cask, a plain-English tasting note, and a confident staff recommendation go a long way. The full ten-day plan is in our [Cask Ale Week guide](/licensees-guide/cask-ale-week-pub-guide).
+September is about easing people back into midweek habits as the nights draw in. **Cask Ale Week (expected 17–27 September)** is the easy excuse to get regulars trying something new and casual drinkers asking questions at the bar — one featured cask, a plain-English tasting note, and a confident staff recommendation go a long way. The full ten-day plan is in our [Cask Ale Week guide](/licensees-guide/cask-ale-week-pub-guide).
 
 The same week, **Macmillan's World's Biggest Coffee Morning (Friday 25 September)** fills a quiet daytime and does some good — coffee, cake, and a reason for the community to gather before the lunch rush.
 
@@ -79,18 +81,18 @@ November is a rugby month. The autumn internationals run through the first three
 
 That last weekend also brings **Black Friday (27 Nov)**, then **Cyber Monday and St Andrew's Day (both Mon 30 Nov)**. Rather than discounting your margin away, sell **gift cards, take Christmas party deposits, and push a January bounce-back voucher** — turn autumn footfall into Christmas bookings. When you're ready for December, our [Christmas pub promotion ideas](/licensees-guide/christmas-pub-promotion-ideas) and guide to [filling December bookings](/licensees-guide/pub-christmas-bookings-fill-december) pick up the baton.
 
-## Your first move
+## Choosing your autumn pub event ideas
 
-Don't try to run the whole calendar. Pick the two or three moments that fit your pub and your crowd, block the dates now, and open bookings early. Brief the team so everyone can talk about what's on, and use every event to capture the next booking before people leave.
+Don't try to run the whole calendar. The best autumn pub event ideas are the two or three that fit your pub and your crowd — so pick those, block the dates now, and open bookings early. Brief the team so everyone can talk about what's on, and use every event to capture the next booking before people leave.
 
-For a month-by-month framework you can reuse every year, use our [seasonal pub events calendar](/licensees-guide/seasonal-pub-events-calendar). For the wider list of formats beyond autumn, see [pub event ideas](/licensees-guide/pub-event-ideas).
+A few of the moments above lean on drinks and entertainment (cask, wine, the rugby), and a few are pure promotion (gifting, the Christmas bounce-back). That mix is deliberate: a good autumn balances something to do with something to sell. If you want more pub entertainment ideas to slot alongside these — quizzes, live music, that sort of thing — and a wider set of bar event ideas and pub promotion ideas for the rest of the year, our [pub event ideas guide](/licensees-guide/pub-event-ideas) is the full list. For a month-by-month framework of seasonal pub marketing ideas you can reuse every year, use our [seasonal pub events calendar](/licensees-guide/seasonal-pub-events-calendar).
 
 If you'd like a hand choosing the right moments for your pub or building the promotion around them, that's what we do at Orange Jelly — see [how we work with pubs](/ways-to-work).
 
 ## FAQs
 
-**What are the best autumn events for a pub?**
-The reliable ones are Cask Ale Week in September, a low-and-no push for Sober October, a wine tasting night, Halloween and Bonfire Night, November rugby, and early Christmas gifting. Pick the two or three that fit your pub.
+**What are the best autumn pub event ideas?**
+The reliable autumn pub event ideas are Cask Ale Week in September, a low-and-no push for Sober October, a wine tasting night, Halloween and Bonfire Night, November rugby, and early Christmas gifting. Pick the two or three that fit your pub.
 
 **When should I start planning autumn?**
 Now. The moments run from mid-September to the end of November, and the pubs that win take bookings weeks ahead. Block the dates and open bookings three to four weeks before each event.

--- a/content/blog/autumn-rugby-nations-championship-pubs.md
+++ b/content/blog/autumn-rugby-nations-championship-pubs.md
@@ -1,38 +1,39 @@
 ---
-title: "Autumn Rugby 2026: Filling Your Pub for the Nations Championship"
+title: "Autumn Internationals 2026: Fill Your Pub for the Rugby"
 slug: "autumn-rugby-nations-championship-pubs"
 publishedDate: 2026-05-25
-excerpt: "Your operator's guide to filling the pub for the new Nations Championship in November 2026. Fixtures, bookings, match platters and a screen checklist that works."
-quickAnswer: "November 2026 brings the new Nations Championship, replacing the Autumn Internationals. There's a marquee home-nation game most weekends from 6 to 21 November, then Finals Weekend at Twickenham, 27 to 29 November. Take table bookings before kick-off, build a simple match-day package, and check your screens and sound work before the room fills."
+excerpt: "Your operator's guide to filling the pub for the autumn internationals in November 2026. Where to watch rugby, table bookings, match platters and a screen checklist."
+quickAnswer: "The autumn internationals are the home nations' November rugby window, and in 2026 they run inside the new Nations Championship. There's a marquee home-nation game most weekends from 6 to 21 November, then Finals Weekend at Twickenham, 27 to 29 November. If you show rugby in your pub, take table bookings before kick-off, build a simple match-day package, and check your screens and sound work before the room fills."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/autumn-rugby-nations-championship-pubs.svg"
 tags:
+  - "autumn internationals"
   - "autumn rugby"
-  - "nations championship"
   - "rugby in pubs"
   - "showing rugby in your pub"
 seasons:
   - autumn
 occasions: []
 status: "published"
-metaDescription: "Fill your pub for the new Nations Championship, November 2026. Home-nation fixtures, table bookings, match platters and a screen and sound checklist for licensees."
+metaDescription: "Fill your pub for the autumn internationals, November 2026. Where to watch rugby, fixtures, table bookings and a screen and sound checklist for licensees."
 keywords:
-  - "autumn rugby 2026"
-  - "nations championship fixtures 2026"
-  - "rugby in pubs"
-  - "showing rugby in your pub"
+  - "autumn internationals"
+  - "autumn internationals rugby"
+  - "where to watch rugby"
+  - "showing rugby in pubs"
+  - "big screen sport pub"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
-  - "when is the rugby on in november 2026"
-  - "nations championship fixtures 2026"
+  - "when are the autumn internationals 2026"
+  - "where to watch the autumn internationals"
   - "how do I get my pub busy for the rugby"
   - "when is the rugby finals weekend 2026"
 faqs:
-  - question: "What is the Nations Championship?"
-    answer: "It's a new global rugby competition launching in 2026 that replaces the standalone Autumn Internationals for the home nations. Through November, teams play a pool of fixtures, then every nation finishes with a placement match at the inaugural Finals Weekend at Twickenham, 27 to 29 November 2026."
+  - question: "What are the autumn internationals in 2026?"
+    answer: "The autumn internationals are the home nations' run of November rugby fixtures against southern-hemisphere sides. In 2026 they sit inside the new Nations Championship: through November the teams play a pool of fixtures, then every nation finishes with a placement match at the inaugural Finals Weekend at Twickenham, 27 to 29 November 2026."
   - question: "When are the November 2026 rugby fixtures?"
     answer: "The November pool window runs from Friday 6 to Saturday 21 November 2026, with a marquee home-nation game most weekends, followed by Finals Weekend at Twickenham from Friday 27 to Sunday 29 November. Confirm kick-off times and TV listings nearer the date, as these can move."
   - question: "How do I get bookings for the rugby?"
@@ -49,27 +50,27 @@ schema:
   "@type": "Article"
 ---
 
-# Autumn Rugby 2026: Filling Your Pub for the Nations Championship
+# Autumn Internationals 2026: Fill Your Pub for the Rugby
 
 *Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
-November used to be a month you survived. The beer garden's done, the Christmas bookings haven't landed, and the dark nights keep people on the sofa. But if you show sport, November is quietly one of the best trading months you've got, because rugby gives people a fixed reason to be out, in a warm room, with a pint in hand.
+November used to be a month you survived. The beer garden's done, the Christmas bookings haven't landed, and the dark nights keep people on the sofa. But the **autumn internationals** change that. If you show rugby in your pub, this is quietly one of the best trading months you've got, because a big game gives people a fixed reason to be out — in a warm room, on a big screen, with a pint in hand.
 
-This year it gets bigger. The new **Nations Championship** launches in 2026 and **replaces the standalone Autumn Internationals** for the home nations. Instead of a loose run of friendlies, you've now got a proper competition with a points table, a pool window through November, and a finale that means something. For a pub, that's the gift that keeps giving: a marquee home-nation game most weekends, and a reason to come back the next one.
+This year it gets bigger. The November window — the **autumn internationals rugby** most of your customers already know by name — now sits inside the new **Nations Championship**. Instead of a loose run of friendlies, you've got a proper competition with a points table, a pool window through November, and a finale that means something. For a pub, that's the gift that keeps giving: a marquee home-nation game most weekends, and a reason to come back the next one.
 
-This guide is the practical version. What's on, how to take the bookings, what to put on a plate, and how to make sure the screens and sound actually deliver when the room's full. It sits alongside [our year-round pub rugby playbook](/licensees-guide/pub-six-nations-rugby-marketing), which covers the Six Nations and the long game; this one is about nailing this November.
+This guide is the practical version. What's on, how to take the bookings, what to put on a plate, and how to make sure the big screen and sound actually deliver when the room's full. It sits alongside [our year-round pub rugby playbook](/licensees-guide/pub-six-nations-rugby-marketing), which covers the Six Nations and the long game; this one is about nailing this November.
 
-## Why November is a rugby month
+## Why the autumn internationals fill a pub
 
-The new format does you a favour. Where the old Autumn Internationals could feel like a scattering of one-off games, the Nations Championship has a shape to it. There's a marquee fixture nearly every weekend in the pool window, the placement matches build toward Finals Weekend, and people who came in for one game have a reason to plan the next.
+The new format does you a favour. Where the old autumn internationals could feel like a scattering of one-off games, sitting them inside the Nations Championship gives the month a shape. There's a marquee fixture nearly every weekend in the pool window, the placement matches build toward Finals Weekend, and people who came in for one game have a reason to plan the next.
 
-That rhythm is exactly what fills a pub. The same logic that makes a weekly quiz work makes a run of rugby weekends work: people learn there's something on, they get into the habit, and they bring others. Your job is to make sure every fixture is in their diary and yours, not left to chance on the day.
+That rhythm is exactly what fills a pub. The same logic that makes a weekly quiz work makes a run of rugby weekends work: people learn there's something on, they get into the habit, and they bring others. And plenty of them are simply searching for where to watch the rugby with a decent screen and a proper pint — so be the obvious answer. Your job is to make sure every fixture is in their diary and yours, not left to chance on the day.
 
-## The fixtures: November 2026
+## The autumn internationals fixtures: November 2026
 
-Here's the home-nation grid for the pool window and the finale. Block these out now, decide which ones you'll build an event around, and get them on your wall planner.
+Here's the home-nation grid for the pool window and the finale. Block these out now, decide which ones you'll build an event around — and which you'll just have on the big screen — and get them on your wall planner.
 
-*Fixtures are correct at the time of writing (last checked 30 May 2026) — confirm kick-off times and TV listings nearer the date.*
+*Provisional and correct at the time of writing (last checked 30 May 2026). Match-ups, kick-off times and TV listings can still move, so confirm each fixture against the official listings nearer the date before you promote it.*
 
 **Pool window (6–21 November)**
 
@@ -148,8 +149,8 @@ If you'd like a hand setting up the bookings, the package and the promotion so y
 
 ## FAQs
 
-**What is the Nations Championship?**
-It's a new global rugby competition launching in 2026 that replaces the standalone Autumn Internationals for the home nations. Teams play a pool of fixtures through November, then every nation finishes with a placement match at the inaugural Finals Weekend at Twickenham, 27 to 29 November 2026.
+**What are the autumn internationals in 2026?**
+The autumn internationals are the home nations' run of November rugby fixtures against southern-hemisphere sides. In 2026 they sit inside the new Nations Championship: teams play a pool of fixtures through November, then every nation finishes with a placement match at the inaugural Finals Weekend at Twickenham, 27 to 29 November 2026.
 
 **When are the November 2026 rugby fixtures?**
 The pool window runs from Friday 6 to Saturday 21 November, with a marquee home-nation game most weekends, followed by Finals Weekend at Twickenham from Friday 27 to Sunday 29 November. Confirm kick-off times and TV listings nearer the date, as they can move.

--- a/content/blog/autumn-rugby-nations-championship-pubs.md
+++ b/content/blog/autumn-rugby-nations-championship-pubs.md
@@ -2,6 +2,7 @@
 title: "Autumn Internationals 2026: Fill Your Pub for the Rugby"
 slug: "autumn-rugby-nations-championship-pubs"
 publishedDate: 2026-05-25
+updatedDate: 2026-05-31
 excerpt: "Your operator's guide to filling the pub for the autumn internationals in November 2026. Where to watch rugby, table bookings, match platters and a screen checklist."
 quickAnswer: "The autumn internationals are the home nations' November rugby window, and in 2026 they run inside the new Nations Championship. There's a marquee home-nation game most weekends from 6 to 21 November, then Finals Weekend at Twickenham, 27 to 29 November. If you show rugby in your pub, take table bookings before kick-off, build a simple match-day package, and check your screens and sound work before the room fills."
 author: "Peter Pitcher"

--- a/content/blog/black-friday-pub-ideas.md
+++ b/content/blog/black-friday-pub-ideas.md
@@ -1,41 +1,42 @@
 ---
-title: "Pub Gift Vouchers: Turn Black Friday Into Bookings"
+title: "Black Friday Ideas for Pubs: Turn It Into Bookings"
 slug: "black-friday-pub-ideas"
 publishedDate: 2026-05-25
-excerpt: "Gift vouchers for pubs are the smartest thing to sell over Black Friday weekend: cash in now, full-margin bookings later. A plan for pub gift cards, deposits and a January bounce-back — no discount war."
-quickAnswer: "Sell gift vouchers for pubs over Black Friday weekend instead of cutting prices. A pub gift card brings cash in now, protects your margin completely, and books a full-price visit for later. Pair it with Christmas party deposits and a January bounce-back voucher, and you turn footfall into bookings rather than bargains."
+updatedDate: 2026-05-31
+excerpt: "Black Friday ideas for pubs that build your December instead of cutting prices: turn the weekend into party deposits, pre-orders, gift-card sales and a January bounce-back. A plan to bank bookings and revenue — no discount war."
+quickAnswer: "The best Black Friday ideas for pubs turn the weekend into December bookings and revenue, not a discount war. Take Christmas party deposits and pre-orders, sell gift cards as a present people are already shopping for, and hand out a January bounce-back voucher. You convert the footfall you've already got into full-price visits later, with your margin intact."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/black-friday-pub-ideas.svg"
 tags:
-  - "gift vouchers for pubs"
+  - "black friday pub ideas"
+  - "christmas party bookings"
   - "pub gift card"
-  - "christmas gift vouchers"
-  - "pub gift card ideas"
+  - "christmas deposits"
 seasons:
   - autumn
   - winter
 occasions:
   - black-friday
 status: "published"
-metaDescription: "Gift vouchers for pubs are the smartest Black Friday play: a pub gift card brings cash in now and books a full-price visit later — no discount war."
+metaDescription: "Black Friday ideas for pubs that build December: take party deposits and pre-orders, sell gift cards, and run a January bounce-back — no discount war."
 keywords:
-  - "gift vouchers for pubs"
+  - "black friday pub ideas"
+  - "christmas party bookings for pubs"
+  - "pub christmas deposits"
   - "pub gift card"
-  - "christmas gift vouchers"
-  - "gift vouchers for restaurants"
-  - "gift card ideas for pubs"
+  - "turn footfall into bookings"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
-  - "how do pubs sell gift vouchers"
-  - "pub gift card ideas"
+  - "black friday ideas for pubs"
+  - "how to fill a pub on black friday weekend"
   - "should a pub discount on black friday"
   - "when is st andrews day 2026"
 faqs:
-  - question: "How do gift vouchers for pubs work on Black Friday?"
-    answer: "Sell a pub gift card or printed voucher in fixed denominations over Black Friday weekend, when people are actively buying Christmas presents. The cash comes in now, you protect your margin completely because you're selling a full-price visit rather than discounting one, and the voucher gets redeemed later — often on a bigger visit than the buyer would have made anyway. Offer two clear amounts: one for a card, one for a meal for two."
+  - question: "What are the best Black Friday ideas for a pub?"
+    answer: "The best Black Friday ideas for a pub turn the weekend into December bookings rather than a discount war. Take party deposits and pre-orders to lock in confirmed Christmas trade, sell gift cards as a present people are already out shopping for, and hand every booking a January bounce-back voucher. You're converting the footfall you've already got into full-price visits later, with your margin completely intact."
   - question: "What's the best way for a pub to sell gift cards at Christmas?"
     answer: "Make a pub gift card easy to buy and easy to give: a physical card or printed voucher people can actually wrap, two clear denominations, on display on the bar, the specials board and social all weekend, and mentioned by every staff member. A code emailed at the till feels like nothing under the tree, so give people something tangible. If you want an incentive, add a little extra credit rather than cutting the price."
   - question: "Should a pub discount on Black Friday?"
@@ -52,29 +53,29 @@ schema:
   "@type": "Article"
 ---
 
-# Pub Gift Vouchers: Turn Black Friday Into Bookings
+# Black Friday Ideas for Pubs: Turn It Into Bookings
 
 *Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
-Here's the smartest thing a pub can sell over Black Friday weekend: gift vouchers. Not money off a round, not a cheap-pint night — **gift vouchers for pubs**, the kind people buy as Christmas presents. Black Friday lands on **Friday 27 November 2026**, and the whole country is in a spending mood, hunting for gifts. A pub gift card is the perfect one: cash in your till now, a full-price visit booked for later, and your margin completely intact.
+Here's the best of the **Black Friday ideas for pubs**: don't run a sale, build your December. Black Friday lands on **Friday 27 November 2026**, the whole country's in a spending mood, and the weekend sits right at the front of the most valuable conversion window in your year. Your job isn't to be the cheapest pub on the road — it's to turn that footfall into confirmed Christmas bookings and full-price revenue: party deposits, pre-orders, a gift card people are already out shopping for, and a January bounce-back.
 
 Most pubs reach for the discount instead, and it's a mistake. A pub is not a shop with a warehouse to clear. When you blanket-discount, you train your best regulars to wait for the cheap night, you tell everyone your normal price is more than it should be, and you hand away the margin you need to get through January. The drinks would have sold anyway. You've just sold them for less.
 
-So flip it. Black Friday sits at the front of the most valuable conversion window in your year, and gifting is what people are actually searching and shopping for that weekend. Use it to sell vouchers, bank deposits and lock in December bookings — not to start a race to the bottom you can't win against the chains.
+So flip it. Use the attention this weekend to bank deposits, take party pre-orders, sell gift cards and lock in December bookings — not to start a race to the bottom you can't win against the chains.
 
 ## The late-November conversion window
 
 Look at what's stacked up in those four days. Black Friday on **Friday 27 November**. The weekend that follows. Then **Monday 30 November**, which this year is both **Cyber Monday** and **St Andrew's Day** — they genuinely fall on the same day in 2026.
 
-That's a run of moments when people are already in a spending mood and already thinking about Christmas presents. You don't need to manufacture a reason to act; the calendar has done it for you. Your job is to point all that attention at the things that actually protect your business: gift vouchers first, then deposits and forward bookings.
+That's a run of moments when people are already in a spending mood and already thinking about Christmas. You don't need to manufacture a reason to act; the calendar has done it for you. Your job is to point all that attention at the things that actually protect your business: deposits and forward bookings first, then gift cards and pre-orders.
 
-Think of it as a conversion window, not a sale. Every person through the door this weekend is a chance to sell a gift card, turn a single visit into a December booking, or hand someone a reason to come back in the dead weeks of January.
+Think of it as a conversion window, not a sale. Every person through the door this weekend is a chance to turn a single visit into a December booking, take a deposit on a party, sell a gift card, or hand someone a reason to come back in the dead weeks of January.
 
-## Sell gift vouchers for pubs, not price cuts
+## Bank Christmas bookings, not price cuts
 
-Gift vouchers are the single best thing a pub can push on Black Friday weekend, and almost nobody does it well. While the chains flog discounts, you're selling the one present nobody else on the high street can: a night at your pub.
+The single best thing a pub can do on Black Friday weekend is convert the people already in front of you into confirmed December trade — and almost nobody does it well. While the chains flog discounts, you're selling the one thing nobody else on the high street can: a booked table at your pub over the festive season.
 
-Here's why a pub gift card works. The cash comes in now, when you want it. A good chunk of cards get spent on higher-value visits — a meal out, a round for friends — not a quiet half. Some are never redeemed at all. And crucially, a gift card protects your margin completely. You're not discounting anything; you're selling the promise of a full-price visit, paid for upfront.
+One of the easiest plays here is the gift card. The cash comes in now, when you want it. A good chunk of cards get spent on higher-value visits — a meal out, a round for friends — not a quiet half. Some are never redeemed at all. And crucially, a gift card protects your margin completely. You're not discounting anything; you're selling the promise of a full-price visit, paid for upfront.
 
 Make them easy to buy and easy to give:
 
@@ -157,8 +158,8 @@ If you'd like a hand turning this weekend into a Christmas booking machine rathe
 
 ## FAQs
 
-**How do gift vouchers for pubs work on Black Friday?**
-Sell a pub gift card or printed voucher in fixed denominations over Black Friday weekend, when people are actively buying Christmas presents. The cash comes in now, you protect your margin completely because you're selling a full-price visit rather than discounting one, and the voucher gets redeemed later — often on a bigger visit than the buyer would have made anyway. Offer two clear amounts: one for a card, one for a meal for two.
+**What are the best Black Friday ideas for a pub?**
+The best Black Friday ideas for a pub turn the weekend into December bookings rather than a discount war. Take party deposits and pre-orders to lock in confirmed Christmas trade, sell gift cards as a present people are already out shopping for, and hand every booking a January bounce-back voucher. You're converting the footfall you've already got into full-price visits later, with your margin completely intact.
 
 **What's the best way for a pub to sell gift cards at Christmas?**
 Make a pub gift card easy to buy and easy to give: a physical card or printed voucher people can actually wrap, two clear denominations, on display on the bar, the specials board and social all weekend, and mentioned by every staff member. A code emailed at the till feels like nothing under the tree, so give people something tangible. If you want an incentive, add a little extra credit rather than cutting the price.

--- a/content/blog/black-friday-pub-ideas.md
+++ b/content/blog/black-friday-pub-ideas.md
@@ -1,46 +1,47 @@
 ---
-title: "Black Friday for Pubs: Gift Cards and Bookings, Not Discounts"
+title: "Pub Gift Vouchers: Turn Black Friday Into Bookings"
 slug: "black-friday-pub-ideas"
 publishedDate: 2026-05-25
-excerpt: "How pubs can use Black Friday weekend to sell gift cards, take Christmas deposits and build a January bounce-back, instead of starting a discount war."
-quickAnswer: "Don't blanket-discount on Black Friday — it trains people to wait for cheap and erodes your margin. Use the weekend to sell gift cards, take Christmas party deposits, push a January bounce-back voucher, and offer limited table packages. Convert footfall into bookings, not bargains."
+excerpt: "Gift vouchers for pubs are the smartest thing to sell over Black Friday weekend: cash in now, full-margin bookings later. A plan for pub gift cards, deposits and a January bounce-back — no discount war."
+quickAnswer: "Sell gift vouchers for pubs over Black Friday weekend instead of cutting prices. A pub gift card brings cash in now, protects your margin completely, and books a full-price visit for later. Pair it with Christmas party deposits and a January bounce-back voucher, and you turn footfall into bookings rather than bargains."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/black-friday-pub-ideas.svg"
 tags:
-  - "black friday pub"
-  - "pub gift cards"
-  - "cyber monday pub"
-  - "st andrews day pub"
+  - "gift vouchers for pubs"
+  - "pub gift card"
+  - "christmas gift vouchers"
+  - "pub gift card ideas"
 seasons:
   - autumn
   - winter
 occasions:
   - black-friday
 status: "published"
-metaDescription: "A Black Friday plan for pubs that protects margin: sell gift cards, take Christmas deposits, run a January bounce-back, and mark St Andrew's Day on 30 November."
+metaDescription: "Gift vouchers for pubs are the smartest Black Friday play: a pub gift card brings cash in now and books a full-price visit later — no discount war."
 keywords:
-  - "black friday pub ideas"
-  - "pub gift cards"
-  - "cyber monday pub"
-  - "st andrews day pub"
+  - "gift vouchers for pubs"
+  - "pub gift card"
+  - "christmas gift vouchers"
+  - "gift vouchers for restaurants"
+  - "gift card ideas for pubs"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
-  - "what should a pub do for black friday"
+  - "how do pubs sell gift vouchers"
   - "pub gift card ideas"
+  - "should a pub discount on black friday"
   - "when is st andrews day 2026"
-  - "how to fill christmas bookings"
 faqs:
-  - question: "What should a pub do for Black Friday?"
-    answer: "Use the weekend to sell gift cards, take Christmas party deposits, and hand out a January bounce-back voucher with every booking. Offer a few limited table packages rather than blanket discounts, so you protect your margin instead of cutting your prices to chase footfall you would have had anyway."
+  - question: "How do gift vouchers for pubs work on Black Friday?"
+    answer: "Sell a pub gift card or printed voucher in fixed denominations over Black Friday weekend, when people are actively buying Christmas presents. The cash comes in now, you protect your margin completely because you're selling a full-price visit rather than discounting one, and the voucher gets redeemed later — often on a bigger visit than the buyer would have made anyway. Offer two clear amounts: one for a card, one for a meal for two."
+  - question: "What's the best way for a pub to sell gift cards at Christmas?"
+    answer: "Make a pub gift card easy to buy and easy to give: a physical card or printed voucher people can actually wrap, two clear denominations, on display on the bar, the specials board and social all weekend, and mentioned by every staff member. A code emailed at the till feels like nothing under the tree, so give people something tangible. If you want an incentive, add a little extra credit rather than cutting the price."
   - question: "Should a pub discount on Black Friday?"
-    answer: "No. Blanket discounting trains your regulars to wait for cheap and erodes the margin you need to get through winter. Sell gift cards and take deposits instead — both bring cash in now and bookings later, without telling people your usual price is too high."
-  - question: "When is St Andrew's Day 2026?"
-    answer: "St Andrew's Day 2026 is Monday 30 November — the same day as Cyber Monday this year. That overlap gives you a ready-made theme for the Monday after Black Friday: Scottish food and drink specials and a Scotland-themed quiz."
+    answer: "No. Blanket discounting trains your regulars to wait for cheap and erodes the margin you need to get through winter. Sell gift vouchers and take Christmas deposits instead — both bring cash in now and bookings later, without telling people your usual price is too high."
   - question: "How do I turn autumn footfall into Christmas bookings?"
-    answer: "Take deposits on every party enquiry, sell party packages with a fixed price per head, push gift cards as easy presents, and give every booking a January bounce-back voucher. Convert the people already in your pub rather than waiting for new ones to find you."
+    answer: "Sell gift vouchers as easy presents, take deposits on every party enquiry, offer party packages at a fixed price per head, and give every booking a January bounce-back voucher. Convert the people already in your pub rather than waiting for new ones to find you."
 ctaSettings:
   ctaType: "contact"
   ctaHeading: "Want a Christmas booking machine, not a discount war?"
@@ -51,38 +52,38 @@ schema:
   "@type": "Article"
 ---
 
-# Black Friday for Pubs: Gift Cards and Bookings, Not Discounts
+# Pub Gift Vouchers: Turn Black Friday Into Bookings
 
 *Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
-Black Friday lands on **Friday 27 November 2026**, and every retailer in the country will be screaming about money off. The temptation is to join in — knock a few quid off a round, run a cheap-pint night, do something so the weekend doesn't feel quiet.
+Here's the smartest thing a pub can sell over Black Friday weekend: gift vouchers. Not money off a round, not a cheap-pint night — **gift vouchers for pubs**, the kind people buy as Christmas presents. Black Friday lands on **Friday 27 November 2026**, and the whole country is in a spending mood, hunting for gifts. A pub gift card is the perfect one: cash in your till now, a full-price visit booked for later, and your margin completely intact.
 
-Don't. A pub is not a shop with a warehouse to clear. When you blanket-discount, you train your best regulars to wait for the cheap night, you tell everyone your normal price is more than it should be, and you hand away the margin you need to get through January. The drinks would have sold anyway. You've just sold them for less.
+Most pubs reach for the discount instead, and it's a mistake. A pub is not a shop with a warehouse to clear. When you blanket-discount, you train your best regulars to wait for the cheap night, you tell everyone your normal price is more than it should be, and you hand away the margin you need to get through January. The drinks would have sold anyway. You've just sold them for less.
 
-There's a far better way to play this weekend, and it doesn't involve cutting a single price. Black Friday sits at the front of the most valuable conversion window in your year. Use it to bank cash now and lock in bookings for December, not to start a race to the bottom you can't win against the chains.
+So flip it. Black Friday sits at the front of the most valuable conversion window in your year, and gifting is what people are actually searching and shopping for that weekend. Use it to sell vouchers, bank deposits and lock in December bookings — not to start a race to the bottom you can't win against the chains.
 
 ## The late-November conversion window
 
 Look at what's stacked up in those four days. Black Friday on **Friday 27 November**. The weekend that follows. Then **Monday 30 November**, which this year is both **Cyber Monday** and **St Andrew's Day** — they genuinely fall on the same day in 2026.
 
-That's a run of moments when people are already in a spending mood and already thinking about Christmas. You don't need to manufacture a reason to act; the calendar has done it for you. Your job is to point all that attention at the things that actually protect your business: gift cards, deposits and forward bookings.
+That's a run of moments when people are already in a spending mood and already thinking about Christmas presents. You don't need to manufacture a reason to act; the calendar has done it for you. Your job is to point all that attention at the things that actually protect your business: gift vouchers first, then deposits and forward bookings.
 
-Think of it as a conversion window, not a sale. Every person through the door this weekend is a chance to turn a single visit into a December booking, a present someone buys from you, or a reason to come back in the dead weeks of January.
+Think of it as a conversion window, not a sale. Every person through the door this weekend is a chance to sell a gift card, turn a single visit into a December booking, or hand someone a reason to come back in the dead weeks of January.
 
-## Sell gift cards instead of cutting prices
+## Sell gift vouchers for pubs, not price cuts
 
-Gift cards are the single best thing a pub can push on Black Friday weekend, and almost nobody does it well.
+Gift vouchers are the single best thing a pub can push on Black Friday weekend, and almost nobody does it well. While the chains flog discounts, you're selling the one present nobody else on the high street can: a night at your pub.
 
-Here's why they work. The cash comes in now, when you want it. A good chunk of cards get spent on higher-value visits — a meal out, a round for friends — not a quiet half. Some are never redeemed at all. And crucially, a gift card protects your margin completely. You're not discounting anything; you're selling the promise of a full-price visit, paid for upfront.
+Here's why a pub gift card works. The cash comes in now, when you want it. A good chunk of cards get spent on higher-value visits — a meal out, a round for friends — not a quiet half. Some are never redeemed at all. And crucially, a gift card protects your margin completely. You're not discounting anything; you're selling the promise of a full-price visit, paid for upfront.
 
 Make them easy to buy and easy to give:
 
 - Have a physical card or a printed voucher people can actually wrap. A code emailed at the till feels like nothing under the tree.
-- Offer a couple of clear denominations — something for a card, something for a proper meal for two.
+- Offer a couple of clear denominations — something for a card, something for a proper meal for two. (The same logic restaurants use for their gift vouchers; a pub gift card just feels warmer.)
 - Put them on the bar, on a table talker, on your specials board, and on social all weekend. People won't ask; you have to offer.
-- Brief every member of staff to mention them on Black Friday: "Sorted your Christmas presents yet? We do gift cards."
+- Brief every member of staff to mention them on Black Friday: "Sorted your Christmas presents yet? We do gift vouchers."
 
-If you want a small incentive, add value rather than cutting it — a little extra credit on a card bought this weekend keeps your headline price intact while still rewarding the buyer.
+If you want a small incentive, add value rather than cutting it — a little extra credit on a card bought this weekend keeps your headline price intact while still rewarding the buyer. That's your best gift card idea for the whole season: more in the wallet, not less on the price.
 
 ## Take Christmas party deposits
 
@@ -100,7 +101,7 @@ If filling December is the real goal here — and it should be — work through 
 
 January is where pubs quietly lose the ground they gained in December. The bounce-back voucher is your defence, and Black Friday weekend is the moment to start handing it out.
 
-The idea is simple: every booking, every gift card, every party deposit comes with a voucher that's only valid in January. You're not discounting now — you're giving people a concrete reason to come back during your quietest stretch.
+The idea is simple: every booking, every gift voucher, every party deposit comes with a bounce-back that's only valid in January. You're not discounting now — you're giving people a concrete reason to come back during your quietest stretch.
 
 - Make it specific and time-boxed: a set offer, redeemable only across a defined window in January.
 - Hand it over physically at the point of booking so it ends up in a wallet, not a spam folder.
@@ -137,17 +138,17 @@ It's a small, cheap layer of effort that turns a flat Cyber Monday into a reason
 
 None of this lives on its own. Black Friday weekend is the on-ramp to your whole festive season, and it works best when it's part of a plan rather than a one-off scramble.
 
-Everything you bank this weekend — the gift cards, the deposits, the bounce-back vouchers — feeds straight into December. So line it up with the bigger picture. Our [Christmas pub promotion ideas](/licensees-guide/christmas-pub-promotion-ideas) cover the wider festive campaign that this weekend kicks off. Both that and the deposit work above sit inside [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas), which maps the whole run from September through to the festive push.
+Everything you bank this weekend — the gift vouchers, the deposits, the bounce-back vouchers — feeds straight into December. So line it up with the bigger picture. Our [Christmas pub promotion ideas](/licensees-guide/christmas-pub-promotion-ideas) cover the wider festive campaign that this weekend kicks off, and gift cards keep selling right up to Christmas Eve. Both that and the deposit work above sit inside [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas), which maps the whole run from September through to the festive push.
 
-At The Anchor in Stanwell Moor, the autumn weekends that pay off are the ones aimed at booking December and protecting January, not at being the cheapest pub on the road. Black Friday is the clearest example of that: a weekend you can either give margin away on, or use to set up your strongest December.
+At The Anchor in Stanwell Moor, the autumn weekends that pay off are the ones aimed at selling gifts, booking December and protecting January, not at being the cheapest pub on the road. Black Friday is the clearest example of that: a weekend you can either give margin away on, or use to put cash in the till and set up your strongest December.
 
 ## Your first move
 
 Don't plan a sale. Plan the conversions.
 
-1. Get gift cards ready to sell — physical or printed, two clear denominations, on every surface and brief to every staff member.
+1. Get gift vouchers ready to sell — a physical pub gift card or printed voucher, two clear denominations, on every surface and brief to every staff member.
 2. Write your fixed-price party package and decide your per-head deposit, then line up your December leads to chase this weekend.
-3. Design a simple January bounce-back voucher to hand over with every booking and card.
+3. Design a simple January bounce-back voucher to hand over with every booking and gift card.
 4. Set up your St Andrew's Day Monday — haggis bon bons, a whisky flight, a Scottish beer, a themed quiz.
 
 Do those four things and Black Friday stops being a weekend you survive and starts being one that builds your winter.
@@ -156,14 +157,14 @@ If you'd like a hand turning this weekend into a Christmas booking machine rathe
 
 ## FAQs
 
-**What should a pub do for Black Friday?**
-Use the weekend to sell gift cards, take Christmas party deposits, and hand out a January bounce-back voucher with every booking. Offer a few limited table packages rather than blanket discounts, so you protect your margin instead of cutting prices to chase footfall you'd have had anyway.
+**How do gift vouchers for pubs work on Black Friday?**
+Sell a pub gift card or printed voucher in fixed denominations over Black Friday weekend, when people are actively buying Christmas presents. The cash comes in now, you protect your margin completely because you're selling a full-price visit rather than discounting one, and the voucher gets redeemed later — often on a bigger visit than the buyer would have made anyway. Offer two clear amounts: one for a card, one for a meal for two.
+
+**What's the best way for a pub to sell gift cards at Christmas?**
+Make a pub gift card easy to buy and easy to give: a physical card or printed voucher people can actually wrap, two clear denominations, on display on the bar, the specials board and social all weekend, and mentioned by every staff member. A code emailed at the till feels like nothing under the tree, so give people something tangible. If you want an incentive, add a little extra credit rather than cutting the price.
 
 **Should a pub discount on Black Friday?**
-No. Blanket discounting trains your regulars to wait for cheap and erodes the margin you need to get through winter. Sell gift cards and take deposits instead — both bring cash in now and bookings later, without telling people your usual price is too high.
-
-**When is St Andrew's Day 2026?**
-St Andrew's Day 2026 is Monday 30 November — the same day as Cyber Monday this year. That overlap gives you a ready-made theme for the Monday after Black Friday: Scottish food and drink specials and a Scotland-themed quiz.
+No. Blanket discounting trains your regulars to wait for cheap and erodes the margin you need to get through winter. Sell gift vouchers and take Christmas deposits instead — both bring cash in now and bookings later, without telling people your usual price is too high.
 
 **How do I turn autumn footfall into Christmas bookings?**
-Take deposits on every party enquiry, sell party packages with a fixed price per head, push gift cards as easy presents, and give every booking a January bounce-back voucher. Convert the people already in your pub rather than waiting for new ones to find you.
+Sell gift vouchers as easy presents, take deposits on every party enquiry, offer party packages at a fixed price per head, and give every booking a January bounce-back voucher. Convert the people already in your pub rather than waiting for new ones to find you.

--- a/content/blog/cask-ale-week-pub-guide.md
+++ b/content/blog/cask-ale-week-pub-guide.md
@@ -2,6 +2,7 @@
 title: "Beer Festival & Cask Ale Week: A 10-Day Plan for Pubs"
 slug: "cask-ale-week-pub-guide"
 publishedDate: 2026-05-25
+updatedDate: 2026-05-31
 excerpt: "Run Cask Ale Week as your own beer festival: a practical 10-day plan with a featured cask, a beer passport, tasting paddles and plain-English notes that turn one week into lasting trade."
 quickAnswer: "Run Cask Ale Week as your own small beer festival. Pick a few cask ales to feature, write a human tasting note for each, give every staff member one to recommend, and add a reason to come back. A simple beer passport gets regulars working through the range across the ten days, and a spot-on cellar means every pint tastes the way it should. You don't need a marquee or a brewery — a handful of well-kept ales and a bit of theatre is a festival."
 author: "Peter Pitcher"
@@ -178,7 +179,7 @@ A few moves that make it stick:
 - **Capture who showed up.** Every passport handed back is someone to tell about your next guest ale. Build the relationship, not just the one sale.
 - **Ask what they liked.** The ales that flew this week are the ones worth keeping on. Let your customers shape your range and they'll feel ownership of it.
 
-Cask Ale Week slots neatly into a busy autumn, alongside Halloween, Bonfire Night and the run-up to Christmas. If you're planning the whole season, [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) pulls it all together so cask is one strong thread rather than a standalone scramble.
+Cask Ale Week slots neatly into a busy autumn, alongside Halloween, Bonfire Night and the run-up to Christmas. It also sits right next to another beer-led moment: if your festival lands late in September, you can roll it straight into [Oktoberfest](/licensees-guide/oktoberfest-pub-guide) on the same kit — different beers, same theatre, two reasons to come in across one fortnight. If you're planning the whole season, [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) pulls it all together so cask is one strong thread rather than a standalone scramble.
 
 ## Your first move
 

--- a/content/blog/cask-ale-week-pub-guide.md
+++ b/content/blog/cask-ale-week-pub-guide.md
@@ -1,39 +1,47 @@
 ---
-title: "Cask Ale Week: A 10-Day Plan to Get Regulars Trying Something New"
+title: "Beer Festival & Cask Ale Week: A 10-Day Plan for Pubs"
 slug: "cask-ale-week-pub-guide"
 publishedDate: 2026-05-25
-excerpt: "A practical 10-day plan for Cask Ale Week 2026: a featured cask, a cask passport, tasting paddles and plain-English tasting notes that turn one week into lasting sales."
-quickAnswer: "Make Cask Ale Week easy. Pick one featured cask, write a human tasting note, give every staff member one recommendation to push, and add a reason to come back. Run a simple cask passport so regulars try different ales across the ten days, and keep your cellar spot-on so every pint tastes the way it should."
+excerpt: "Run Cask Ale Week as your own beer festival: a practical 10-day plan with a featured cask, a beer passport, tasting paddles and plain-English notes that turn one week into lasting trade."
+quickAnswer: "Run Cask Ale Week as your own small beer festival. Pick a few cask ales to feature, write a human tasting note for each, give every staff member one to recommend, and add a reason to come back. A simple beer passport gets regulars working through the range across the ten days, and a spot-on cellar means every pint tastes the way it should. You don't need a marquee or a brewery — a handful of well-kept ales and a bit of theatre is a festival."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/cask-ale-week-pub-guide.svg"
 tags:
+  - "beer festival"
   - "cask ale week"
+  - "real ale festival"
   - "cask ale"
-  - "real ale pub"
   - "pub events"
 seasons:
   - autumn
 occasions: []
 status: "published"
-metaDescription: "Cask Ale Week 2026 runs 17–27 September. A practical 10-day plan for pubs: featured cask, cask passport, tasting paddles and plain-English notes that build lasting sales."
+metaDescription: "Run your own beer festival around Cask Ale Week 2026: a 10-day pub plan with featured casks, a beer passport, tasting paddles and plain-English notes."
 keywords:
-  - "cask ale week ideas for pubs"
+  - "beer festival ideas for pubs"
+  - "how to run a beer festival in a pub"
+  - "real ale festival"
+  - "craft beer festival"
   - "cask ale week 2026"
-  - "how to promote cask ale"
-  - "real ale events pub"
+  - "meet the brewer event"
+  - "cask ale week ideas for pubs"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
+  - "how to run a beer festival in a pub"
   - "when is cask ale week 2026"
-  - "how do I run a cask passport in my pub"
+  - "beer festival ideas for a small pub"
+  - "how do I run a beer passport in my pub"
   - "how to get customers to try cask ale"
   - "how to keep cask ale in good condition"
 faqs:
+  - question: "How do I run a beer festival in my pub?"
+    answer: "You don't need a marquee or a brewery to call it a festival. Pick a handful of cask ales to feature across the run, give it a name and a bit of theatre, and add a beer passport so drinkers work through the range. Cask Ale Week in September is the perfect hook to hang it on. Keep the cellar spot-on, brief your team to recommend, and a small real ale festival comes together with kit you already own."
   - question: "When is Cask Ale Week 2026?"
-    answer: "Cask Ale Week runs Thursday 17 to Sunday 27 September 2026. That gives you two weekends and the midweek in between, so it works as a proper ten-day campaign rather than a single night you have to cram everything into."
-  - question: "How do I run a cask passport?"
+    answer: "Cask Ale Week runs in late September; the 2026 dates are expected to be Thursday 17 to Sunday 27 September (confirm at caskaleweek.co.uk). That gives you two weekends and the midweek in between, so it works as a proper ten-day campaign rather than a single night you have to cram everything into."
+  - question: "How do I run a beer passport?"
     answer: "Print a simple card listing the cask ales you'll feature across the run. Every time a customer buys a different one, stamp or tick it off. Set a reachable target, say four ales, and reward a completed card with something small like a free half or a branded glass. It quietly turns one pint into several visits."
   - question: "How do I get customers to try cask ale?"
     answer: "Lower the risk and make it human. Offer a third-pint or a small taster before they commit, describe each ale in plain English rather than brewery jargon, and have staff recommend one personally. Most people who say they don't like 'real ale' just haven't found the right one yet."
@@ -49,17 +57,32 @@ schema:
   "@type": "Article"
 ---
 
-# Cask Ale Week: A 10-Day Plan to Get Regulars Trying Something New
+# Beer Festival & Cask Ale Week: A 10-Day Plan for Pubs
 
 *Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
-Cask is one of the few things a chain down the road can't really copy. They can match your prices and out-spend your marketing, but a well-kept cask ale, poured by someone who can tell you what it tastes like, is properly your patch. The trouble is most of us never make a fuss about it. The handpulls just sit there, and half your customers walk past them every week without ever giving one a go.
+You don't need a marquee, a field, or a dozen breweries to run a beer festival. The best one you can put on is the pub you've already got, a handful of well-kept ales, and a week with a name on it. Cask is one of the few things a chain down the road can't really copy. They'll match your prices and out-spend your marketing, but a well-kept cask, poured by someone who can tell you what it tastes like, is properly your patch. The trouble is most of us never make a fuss about it. The handpulls just sit there, and half your customers walk past them every week without giving one a go.
 
-Cask Ale Week is the nudge that fixes that. It gives you the one thing that's hard to manufacture on a normal Tuesday: a reason. A reason for regulars to try the pump they always ignore, a reason for lager drinkers to be curious, and a reason for you to talk about the thing you're already good at.
+Cask Ale Week is the nudge that fixes that — and the perfect hook to turn a normal September into your own beer festival. It gives you the one thing that's hard to manufacture on a wet Tuesday: a reason. A reason for regulars to try the pump they always ignore, a reason for lager drinkers to be curious, and a reason for you to talk about the thing you're already good at.
 
-**Cask Ale Week runs Thursday 17 to Sunday 27 September 2026.** That's two weekends with the midweek in between, so you've got room to build something over ten days rather than blowing it all on one night.
+**Cask Ale Week runs in late September — expect Thursday 17 to Sunday 27 September in 2026 (confirm the dates at caskaleweek.co.uk).** That's two weekends with the midweek in between, so you've got room to build something over ten days rather than blowing it all on one night.
 
 This guide is the practical version. No beer-bore lectures, no kit you don't already own. Just a simple plan to get more people drinking your cask, and to keep some of them doing it long after the week is over.
+
+## Run it as your own beer festival
+
+Here's the reframe that makes the week land harder: don't call it "we've got some ales on," call it a festival. The word does real work. A beer festival sounds like an event worth a trip and a text to a mate; a few extra handpulls sounds like a normal Tuesday. Same ales, same cellar, completely different pull.
+
+And you can absolutely earn the word without the overheads. People picture a real ale festival as a marquee and a hundred firkins on stillage. It can be — but for most of us it's better as a small, well-run thing: a curated handful of cask ales, a name, a passport, and a bit of theatre. That's a festival your regulars will actually turn up to, run on kit you already own.
+
+A few ways to dress it up so it reads as an event:
+
+- **Give it a name and a look.** "[Your Pub] Autumn Ale Festival" on a chalkboard A-board, a printed list on every table, a hashtag. Naming it is half the job — it tells people something's on.
+- **Curate a theme.** Pick an angle so the line-up tells a story: all local breweries, a darker-beers week as the nights draw in, or a "best of British bitter" run. A theme gives you something to talk about and a reason for the curious to come.
+- **Widen the tent if it suits you.** If your crowd leans younger, run it as a craft beer festival too — a couple of keg lines or cans alongside the cask, so hop-forward drinkers have a way in. The point is range and occasion, not purism.
+- **Programme it lightly.** A "meet the brewer" slot one evening, a tap-takeover feel at the weekend, the new ale revealed each morning. You're giving the week a shape so it feels like a festival, not a fridge.
+
+The rest of this guide is the engine room of that festival — the daily formats, the passport, the paddles and the cellar work that make it run. Lift what fits, slap a name on it, and you've got a beer festival that's unmistakably yours.
 
 ## The simple version (start here)
 
@@ -96,9 +119,9 @@ The single biggest barrier to trying cask is risk. Nobody wants to spend on a fu
 
 Where your licence and glassware allow, offer a third-pint flight — three small measures on a paddle so people can taste and compare without committing to a pint. It turns "I don't really drink real ale" into "go on then," and the one they like becomes the pint they order next. If you can't do paddles, a small taster before they buy does the same job for free.
 
-### A low-effort "meet the maker" night
+### A low-effort meet the brewer event
 
-You don't need to fly in a head brewer. A "meet the maker" night can be as simple as your local or regional brewery sending a rep along for a couple of hours on a weekend evening, pouring their ale and chatting to drinkers. Many will jump at it — it's their shop window too — and they'll often bring glassware, pump clips and point-of-sale with them.
+A meet the brewer event is the bit that makes the week feel like a proper festival, and it's easier to pull off than it sounds. You don't need to fly in a head brewer. It can be as simple as your local or regional brewery sending a rep along for a couple of hours on a weekend evening, pouring their ale and chatting to drinkers. Many will jump at it — it's their shop window too — and they'll often bring glassware, pump clips and point-of-sale with them.
 
 If that's a stretch, run a "meet the cask" instead: you behind the bar, one good ale, a few words about where it's from and why you put it on. People love a story with their pint, and you're the maker of the experience whether or not a brewer turns up.
 
@@ -172,10 +195,13 @@ If you'd like a hand turning the week into a proper plan, or making cask the her
 
 ## FAQs
 
-**When is Cask Ale Week 2026?**
-Cask Ale Week runs Thursday 17 to Sunday 27 September 2026. That gives you two weekends and the midweek in between, so it works as a proper ten-day campaign rather than a single night you have to cram everything into.
+**How do I run a beer festival in my pub?**
+You don't need a marquee or a brewery to call it a festival. Pick a handful of cask ales to feature across the run, give it a name and a bit of theatre, and add a beer passport so drinkers work through the range. Cask Ale Week in September is the perfect hook to hang it on. Keep the cellar spot-on, brief your team to recommend, and a small real ale festival comes together with kit you already own.
 
-**How do I run a cask passport?**
+**When is Cask Ale Week 2026?**
+Cask Ale Week runs in late September; the 2026 dates are expected to be Thursday 17 to Sunday 27 September (confirm at caskaleweek.co.uk). That gives you two weekends and the midweek in between, so it works as a proper ten-day campaign rather than a single night you have to cram everything into.
+
+**How do I run a beer passport?**
 Print a simple card listing the cask ales you'll feature across the run. Every time a customer buys a different one, stamp or tick it off. Set a reachable target, say four ales, and reward a completed card with something small like a free half or a branded glass. It quietly turns one pint into several visits.
 
 **How do I get customers to try cask ale?**

--- a/content/blog/macmillan-coffee-morning-pub-guide.md
+++ b/content/blog/macmillan-coffee-morning-pub-guide.md
@@ -1,27 +1,29 @@
 ---
-title: "How to Host a Macmillan Coffee Morning in Your Pub"
+title: "Coffee Morning Ideas for Pubs: Fundraising That Works"
 slug: "macmillan-coffee-morning-pub-guide"
 publishedDate: 2026-05-25
-excerpt: "A practical, operator-to-operator guide to hosting a Macmillan Coffee Morning in your pub: a simple run-sheet, how it pays for a wet-led pub, and how to promote it."
-quickAnswer: "Pick a date that suits you, put on coffee and cake with a donation jar and a raffle, and tie in a local group to bring people through the door. It fills a quiet daytime, lifts food and drink spend, and earns real goodwill. Sign up for the free pack at macmillan.org.uk/coffee-morning."
+excerpt: "Coffee morning ideas that fill a quiet daytime and raise money: a simple run-sheet, a raffle, a local-group tie-in, and how to make a Macmillan Coffee Morning pay for a wet-led pub."
+quickAnswer: "The best coffee morning ideas for pubs are the simple ones: put on coffee and cake with a donation jar, add a raffle, and tie in a local group to bring a crowd. It's one of the easiest charity fundraising ideas going — it fills a quiet daytime, lifts food and drink spend, and earns real goodwill. For the September date, sign up for the free Macmillan pack at macmillan.org.uk/coffee-morning."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/macmillan-coffee-morning-pub-guide.svg"
 tags:
+  - "coffee morning ideas"
   - "macmillan coffee morning"
-  - "pub fundraising event"
-  - "pub coffee morning"
+  - "pub fundraising"
+  - "charity event ideas"
   - "community pub events"
 seasons:
   - autumn
 occasions: []
 status: "published"
-metaDescription: "How to host a Macmillan Coffee Morning in your pub: a simple run-sheet, why it pays for a wet-led pub, and how to promote it. Date for 2026 and the free pack."
+metaDescription: "Coffee morning ideas for pubs: a simple run-sheet, raffle and local-group tie-in that fill a quiet daytime and raise money. Plus the Macmillan 2026 date."
 keywords:
-  - "macmillan coffee morning pub"
-  - "pub charity event ideas"
-  - "how to host a coffee morning"
-  - "community fundraising pub"
+  - "coffee morning ideas"
+  - "macmillan coffee morning ideas"
+  - "charity fundraising ideas"
+  - "fundraising ideas for pubs"
+  - "charity event ideas for pubs"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
@@ -31,14 +33,16 @@ voiceSearchQueries:
   - "pub charity event ideas"
   - "how to raise money for charity in a pub"
 faqs:
+  - question: "What are the best coffee morning ideas for a pub?"
+    answer: "Keep it simple. Coffee and cake on a suggested donation, a raffle with prizes from local businesses, a donation jar with a QR code for card giving, and a local group invited in to make a crowd. Those four coffee morning ideas do the heavy lifting. Tie it to Macmillan's September date for the national push, or run your own any month of the year."
   - question: "When is the Macmillan Coffee Morning 2026?"
     answer: "Macmillan's World's Biggest Coffee Morning falls on Friday 25 September 2026, the last Friday of the month. You don't have to use that date, though. Macmillan are clear that you can host on any day that suits your pub and your week."
-  - question: "How do I host a Macmillan Coffee Morning in a pub?"
-    answer: "Sign up for the free pack at macmillan.org.uk/coffee-morning, pick a daytime slot, and put on coffee and cake with a donation jar. Add a raffle and tie in a local group to bring a crowd. Promote it for two to three weeks across your socials, local groups and Google Business Profile."
+  - question: "What are good charity fundraising ideas for pubs beyond a coffee morning?"
+    answer: "A coffee morning is the easiest place to start, but the same playbook powers most fundraising ideas for pubs: a raffle, a quiz night with the entry fee donated, a sponsored event, an auction of local prizes, or a themed food night with a fixed donation per cover. Pick one cause, make giving effortless with a jar and a QR code, and let your regulars rally round it."
   - question: "How does a coffee morning make money for a wet-led pub?"
-    answer: "The donations go to Macmillan, but the footfall is yours. People who'd never normally be in at 10am come through the door, many stay for lunch or a drink, and your regulars see you backing a cause they care about. It fills a dead daytime and builds goodwill that pays off for weeks."
+    answer: "The donations go to the charity, but the footfall is yours. People who'd never normally be in at 10am come through the door, many stay for lunch or a drink, and your regulars see you backing a cause they care about. It fills a dead daytime and builds goodwill that pays off for weeks."
   - question: "Do I need anything official to fundraise?"
-    answer: "Macmillan provide everything you need in their free fundraising pack, including posters, bunting and a guide. Sign up at macmillan.org.uk/coffee-morning. Beyond that, just run it sensibly within your normal licensed hours and area, and you're set."
+    answer: "For a Macmillan Coffee Morning, the free pack at macmillan.org.uk/coffee-morning gives you posters, bunting and a guide. For your own fundraiser, just run it sensibly within your normal licensed hours and area. If your plan steps outside those, check your premises licence and speak to your council about a Temporary Event Notice."
 ctaSettings:
   ctaType: "contact"
   ctaHeading: "Want help filling your quiet daytimes?"
@@ -49,13 +53,13 @@ schema:
   "@type": "Article"
 ---
 
-# How to Host a Macmillan Coffee Morning in Your Pub
+# Coffee Morning Ideas for Pubs: Fundraising That Works
 
 *Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
 Most pubs treat the daytime as a write-off. The doors are open, the lights are on, a member of staff is leaning on the bar, and barely anyone comes in until lunch. That quiet stretch between opening and the first proper rush is where a surprising amount of money quietly leaks away every single week.
 
-A coffee morning is one of the simplest ways to plug that gap. It gives people a specific reason to come in at a time they'd usually skip, it costs you almost nothing to run, and it does it under the banner of a cause everyone already understands and respects. Macmillan's World's Biggest Coffee Morning is the obvious hook, and it sits perfectly alongside a Greene King autumn toolkit, because autumn daytimes are exactly when the pub goes quiet.
+The best coffee morning ideas plug that gap. A coffee morning gives people a specific reason to come in at a time they'd usually skip, it costs you almost nothing to run, and it does it under the banner of a cause everyone already understands and respects. As charity fundraising ideas for a pub go, it's about the lowest-risk one there is. Macmillan's World's Biggest Coffee Morning is the obvious hook, and it sits perfectly alongside a Greene King autumn toolkit, because autumn daytimes are exactly when the pub goes quiet.
 
 At The Anchor in Stanwell Moor, the daytime sessions we've turned around have all started the same way: with one reliable reason for people to walk through the door before lunch. A coffee morning is about as easy a reason as you'll find.
 
@@ -67,9 +71,9 @@ But here's the bit a lot of licensees miss. Macmillan are completely clear that 
 
 So treat the 25th as the anchor and the option, not the rule. Pick the slot in your week that's flattest, and put the coffee morning there.
 
-## A simple run-sheet you can lift straight away
+## Coffee morning ideas: a simple run-sheet you can lift straight away
 
-You don't need to overthink this. The whole point is that it's low-effort and low-risk. Here's the shape of it.
+You don't need to overthink this. The whole point is that it's low-effort and low-risk. The good coffee morning ideas are nearly always the plain ones — coffee, cake, a raffle and a reason for a crowd to turn up together. Here's the shape of it.
 
 ### Coffee and cake — the core
 
@@ -92,6 +96,17 @@ Have a clearly labelled jar on the bar, but don't rely on cash alone — fewer p
 This is what turns a quiet coffee morning into a busy one. Invite a local group to make your pub their home for the morning — the WI, a baby-and-toddler group, a walking club, the local history society, a knit-and-natter. They get a warm room and a focus; you get a crowd that arrives together, stays a while, and brings people who've never set foot in your pub before. Pick a group whose timing suits a daytime and whose members are exactly the kind of new faces you'd love to see again.
 
 For more on the mechanics that apply to any event like this — hosting it properly, running a clean run-sheet, promoting it early — our guide to [running successful pub events](/licensees-guide/how-to-run-successful-pub-events) is worth a read alongside this one.
+
+## Beyond the coffee morning: charity event ideas for pubs
+
+A coffee morning is the easiest way in, but it's not the only one. Once you've run one, you'll spot how the same four moves — pick a cause, make giving effortless, give people a reason to gather, draw a raffle — power almost every fundraiser. A few charity event ideas for pubs that use exactly that engine:
+
+- **A charity quiz night.** Run your normal quiz and donate the entry fee, or add a £1-a-head charity round. You're already pulling a crowd; you're just pointing the goodwill somewhere.
+- **A raffle or auction of local prizes.** The butcher's hamper, a meal for two, a signed shirt from the club down the road. Local businesses give gladly for the mention, and people bid higher when it's for a cause.
+- **A themed food night with a donation per cover.** A curry night, a pie night, a Sunday with a quid from every roast going to the pot. It lifts covers and does some good.
+- **A sponsored effort.** A staff head-shave, a darts marathon, a sponsored walk that starts and finishes at the bar. Daft, memorable, and people turn out to watch.
+
+The point isn't to do all of these. It's to see that fundraising ideas for pubs nearly always come back to the same simple recipe — and a coffee morning is the gentlest place to learn it.
 
 ## How it actually pays for a wet-led pub
 
@@ -149,14 +164,17 @@ If you'd like a hand filling your quiet daytimes — picking the right format, g
 
 ## FAQs
 
+**What are the best coffee morning ideas for a pub?**
+Keep it simple. Coffee and cake on a suggested donation, a raffle with prizes from local businesses, a donation jar with a QR code for card giving, and a local group invited in to make a crowd. Those four coffee morning ideas do the heavy lifting. Tie it to Macmillan's September date for the national push, or run your own any month of the year.
+
 **When is the Macmillan Coffee Morning 2026?**
 Macmillan's World's Biggest Coffee Morning falls on Friday 25 September 2026, the last Friday of the month. You don't have to use that date, though — Macmillan are clear you can host on any day that suits your pub and your week.
 
-**How do I host a Macmillan Coffee Morning in a pub?**
-Sign up for the free pack at macmillan.org.uk/coffee-morning, pick a daytime slot, and put on coffee and cake with a donation jar. Add a raffle and tie in a local group to bring a crowd. Promote it for two to three weeks across your socials, local groups and Google Business Profile.
+**What are good charity fundraising ideas for pubs beyond a coffee morning?**
+A coffee morning is the easiest place to start, but the same playbook powers most fundraising ideas for pubs: a raffle, a quiz night with the entry fee donated, a sponsored event, an auction of local prizes, or a themed food night with a fixed donation per cover. Pick one cause, make giving effortless with a jar and a QR code, and let your regulars rally round it.
 
 **How does a coffee morning make money for a wet-led pub?**
-The donations go to Macmillan, but the footfall is yours. People who'd never normally be in before lunch come through the door, many stay for food or a drink, and your regulars see you backing a cause they care about. It fills a dead daytime and builds goodwill that pays off for weeks.
+The donations go to the charity, but the footfall is yours. People who'd never normally be in at 10am come through the door, many stay for lunch or a drink, and your regulars see you backing a cause they care about. It fills a dead daytime and builds goodwill that pays off for weeks.
 
 **Do I need anything official to fundraise?**
-Macmillan provide everything in their free fundraising pack, including posters, bunting and a guide — sign up at macmillan.org.uk/coffee-morning. Keep serving responsibly under Challenge 25, and if your plan steps outside your normal hours or licensed area, check your premises licence and your council about a Temporary Event Notice.
+For a Macmillan Coffee Morning, the free pack at macmillan.org.uk/coffee-morning gives you posters, bunting and a guide. For your own fundraiser, just run it sensibly within your normal licensed hours and area. If your plan steps outside those, check your premises licence and speak to your council about a Temporary Event Notice.

--- a/content/blog/macmillan-coffee-morning-pub-guide.md
+++ b/content/blog/macmillan-coffee-morning-pub-guide.md
@@ -2,6 +2,7 @@
 title: "Coffee Morning Ideas for Pubs: Fundraising That Works"
 slug: "macmillan-coffee-morning-pub-guide"
 publishedDate: 2026-05-25
+updatedDate: 2026-05-31
 excerpt: "Coffee morning ideas that fill a quiet daytime and raise money: a simple run-sheet, a raffle, a local-group tie-in, and how to make a Macmillan Coffee Morning pay for a wet-led pub."
 quickAnswer: "The best coffee morning ideas for pubs are the simple ones: put on coffee and cake with a donation jar, add a raffle, and tie in a local group to bring a crowd. It's one of the easiest charity fundraising ideas going — it fills a quiet daytime, lifts food and drink spend, and earns real goodwill. For the September date, sign up for the free Macmillan pack at macmillan.org.uk/coffee-morning."
 author: "Peter Pitcher"
@@ -142,7 +143,7 @@ The first coffee morning is the hard one. By the second or third, people know wh
 
 You don't have to wait a full year between them, either. The Macmillan morning in September is a brilliant launchpad, but the format works any month. A monthly or seasonal coffee morning — tied to a different local group each time, or to a seasonal moment — keeps that quiet daytime working for you all year round and gives a whole crowd of people a standing reason to choose your pub before lunch.
 
-It also slots neatly into a wider plan. If you want to build out the rest of your autumn around it, [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) maps out a September-to-November calendar you can drop a coffee morning straight into.
+It also slots neatly into a wider plan. A late-September coffee morning is the gentle opener; a few weeks later your [Halloween and Bonfire Night events](/licensees-guide/pub-halloween-bonfire-night-events) bring the louder, family-and-evening trade, and the two together carry a quiet autumn from daytime right through to the dark nights. If you want to build out the rest of your autumn around it, [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) maps out a September-to-November calendar you can drop a coffee morning straight into.
 
 ## A quick word on doing it properly
 

--- a/content/blog/national-drinks-days-pub-guide.md
+++ b/content/blog/national-drinks-days-pub-guide.md
@@ -1,40 +1,49 @@
 ---
-title: "Vodka, Gin and Champagne Days: Easy Autumn Drinks Activations"
+title: "National Vodka Day & Drinks Days: A Pub Calendar"
 slug: "national-drinks-days-pub-guide"
 publishedDate: 2026-05-25
-excerpt: "Three autumn drinks days your pub can run in a single shift. Vodka, gin and tonic, and a Champagne weekend, with serves, pricing and promotion that actually work."
-quickAnswer: "Three autumn drinks days fit neatly into the run-up to Christmas: National Vodka Day on Sunday 4 October, International Gin and Tonic Day on Monday 19 October, and Champagne Day, which you run as a weekend on Friday 23 and Saturday 24 October. Each needs one featured serve, one chalkboard and one social post."
+excerpt: "A pub calendar of national drinks days to pick from, anchored by National Vodka Day. Pick a hook, run it in one shift, with serves, pricing and promotion that work."
+quickAnswer: "National Vodka Day is Sunday 4 October 2026, and it anchors a calendar of national drinks days a pub can pick from. The easy autumn run is National Vodka Day (4 Oct), International Gin and Tonic Day (19 Oct) and Champagne Day (the fourth Friday of October, 23 Oct 2026). Earlier in the year you've also got World Gin Day, National Beer Day, National Prosecco Day and World Cocktail Day. Each needs one featured serve, one chalkboard and one social post."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/national-drinks-days-pub-guide.svg"
 tags:
   - "national vodka day"
-  - "international gin and tonic day"
-  - "champagne day"
+  - "national drinks days"
+  - "world gin day"
+  - "international champagne day"
   - "pub drinks promotion"
 seasons:
   - autumn
 occasions: []
 status: "published"
-metaDescription: "National Vodka Day, Gin and Tonic Day and Champagne Day for pubs. Low-effort, high-margin autumn drinks activations with serves, pricing and promotion that work."
+metaDescription: "National Vodka Day and a calendar of national drinks days for pubs, from world gin day to national beer day. Low-effort serves, pricing and promotion."
 keywords:
-  - "national vodka day 2026"
-  - "international gin and tonic day"
-  - "champagne day pub"
-  - "pub cocktail promotion ideas"
+  - "national vodka day"
+  - "national drinks days"
+  - "world gin day"
+  - "national beer day"
+  - "national cocktail day"
+  - "national prosecco day"
+  - "international champagne day"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
   - "when is national vodka day 2026"
-  - "when is international gin and tonic day 2026"
+  - "what national drinks days can a pub run"
+  - "when is world gin day 2026"
+  - "when is national beer day 2026"
   - "when is champagne day 2026"
-  - "pub cocktail promotion ideas"
 faqs:
   - question: "When is National Vodka Day 2026?"
-    answer: "National Vodka Day is Sunday 4 October 2026. It lands perfectly on a Sunday, so build it around a Bloody Mary brunch or a signature martini and run it alongside your usual roast trade."
-  - question: "When is International Gin and Tonic Day 2026?"
-    answer: "International Gin and Tonic Day is Monday 19 October 2026. A Monday is one of the quietest nights of the week, which is exactly why a G&T board and a local gin spotlight earn their keep here."
+    answer: "National Vodka Day is Sunday 4 October 2026. It lands perfectly on a Sunday, so build it around a Bloody Mary brunch or a signature martini and run it alongside your usual roast trade. It's also the easiest of the national drinks days to start with."
+  - question: "What national drinks days can a pub run through the year?"
+    answer: "Plenty, and you only need a few. The easy autumn run is National Vodka Day (4 October), International Gin and Tonic Day (19 October) and Champagne Day (the fourth Friday of October, 23 October 2026). Earlier in the year there's World Gin Day (the second Saturday of June), National Beer Day or Beer Day Britain (15 June), National Prosecco Day (13 August) and World Cocktail Day (13 May). Pick the ones that suit your crowd rather than chasing all of them."
+  - question: "When is World Gin Day 2026?"
+    answer: "World Gin Day falls on the second Saturday of June, which is 13 June 2026. Being a Saturday it suits a proper gin board and a local distillery spotlight, where International Gin and Tonic Day on 19 October is better as a quiet-Monday lift."
+  - question: "When is National Beer Day 2026?"
+    answer: "National Beer Day in Britain, also called Beer Day Britain, is 15 June every year, which in 2026 is a Monday. It's tied to the sealing of Magna Carta and has a 7pm Cheers to Beer toast, so it's an easy excuse to feature a local cask or a guest beer."
   - question: "When is Champagne Day 2026?"
     answer: "International Champagne Day falls on the fourth Friday of October, which is Friday 23 October 2026. Run it as a Champagne Weekend across Friday 23 and Saturday 24 October so you keep the Saturday trade too."
   - question: "How do I run a low-effort drinks day in a pub?"
@@ -49,15 +58,29 @@ schema:
   "@type": "Article"
 ---
 
-# Vodka, Gin and Champagne Days: Easy Autumn Drinks Activations
+# National Vodka Day & Drinks Days: A Pub Calendar to Pick From
 
 *Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
-Autumn is full of awkward gaps. The garden has gone quiet, Christmas bookings haven't landed yet, and the weeks between the August bank holiday and December can drift. You don't always have the time or the team to put on a full event in that window, and you don't need to.
+National Vodka Day is Sunday 4 October 2026, and it's the easiest place to start with national drinks days in your pub. There's a recognised day for nearly every spirit and style now, which sounds like a lot until you realise you don't have to run them all. You just pick the handful that suit your crowd and treat each one as a single featured serve, not a full event.
 
-This is where single-serve drinks days earn their place. National Vodka Day, International Gin and Tonic Day, Champagne Day. They're not events in the way a quiz or a pop-up is. There's no booking sheet, no host, no run-sheet. There's one drink, one reason to mention it, and a higher spend per head on a day that would otherwise tick along on the usual.
+That's the difference. A drinks day isn't a quiz or a pop-up. There's no booking sheet, no host, no run-sheet. There's one drink, one reason to mention it, and a higher spend per head on a day that would otherwise tick along on the usual.
 
-Three of them fall in October, neatly spaced through the month, right when you want to keep people in the habit of coming in before the Christmas rush starts. This guide covers exactly how to run each one in a single shift, and how to price them so they actually move your margin rather than just your stock.
+Three of the best fall in October, neatly spaced through the month, right when you want to keep people in the habit of coming in before the Christmas rush starts. Below is a calendar you can pick from, then exactly how to run any one of them in a single shift, and how to price them so they actually move your margin rather than just your stock.
+
+## The national drinks days calendar (pick what suits you)
+
+Here's the shortlist worth a pub's attention. Dates that move around are described by their rule as well, so you can plan ahead without second-guessing.
+
+- **World Cocktail Day — Wednesday 13 May 2026.** The internationally recognised one (the UK also nods to National Cocktail Day on 24 March). A single signature cocktail on the board is plenty.
+- **World Gin Day — Saturday 13 June 2026** (the second Saturday of June). A Saturday, so it suits a proper gin board and a local distillery spotlight.
+- **National Beer Day — Monday 15 June 2026.** Also called Beer Day Britain, fixed to 15 June and tied to Magna Carta, with a 7pm Cheers to Beer toast. A gift if you keep cask.
+- **National Prosecco Day — Thursday 13 August 2026.** High summer, fizz by the glass, garden weather. Easy yes for a treat.
+- **National Vodka Day — Sunday 4 October 2026.** Lands on a Sunday, so it rides alongside your roast trade. The pick of the bunch to start with.
+- **International Gin and Tonic Day — Monday 19 October 2026.** A quiet Monday, which is exactly why a G&T lift earns its keep.
+- **International Champagne Day — Friday 23 October 2026** (the fourth Friday of October). Run it as a weekend and keep the Saturday too.
+
+You won't run all seven, and you shouldn't try. The three October dates make the tidiest autumn run, so the rest of this guide works through those in detail. The earlier dates are there for when you're planning the wider year.
 
 ## Why a single drink is the easiest hook you've got
 
@@ -65,7 +88,7 @@ A spirit has a built-in story. People already know what a martini is, what a goo
 
 That's the whole trick. A featured serve nudges spend per head up without asking anyone to plan their week around you. The drinks are high-margin to begin with, the theatre is free, and the prep is minimal. One chalkboard does most of the marketing in the room. One social post does the rest outside it.
 
-And because each of these days is a recognised date, you're borrowing a hook that's already in people's heads. You don't have to explain why today is vodka day. You just have to have something worth ordering when they walk in.
+And because each of these national drinks days is a recognised date, you're borrowing a hook that's already in people's heads. You don't have to explain why today is vodka day. You just have to have something worth ordering when they walk in.
 
 A quick word before the fun bit: these days are about trading up, not drinking more. Keep your sensible drinks messaging visible, run Challenge 25 as you always do, and a small Drinkaware line on the menu never goes amiss.
 
@@ -142,10 +165,16 @@ If you'd like a hand building a drinks offer that genuinely lifts spend rather t
 ## FAQs
 
 **When is National Vodka Day 2026?**
-National Vodka Day is Sunday 4 October 2026. It lands on a Sunday, so build it around a Bloody Mary brunch or a signature martini and let it run alongside your roast trade.
+National Vodka Day is Sunday 4 October 2026. It lands on a Sunday, so build it around a Bloody Mary brunch or a signature martini and let it run alongside your roast trade. It's also the easiest of the national drinks days to start with.
 
-**When is International Gin and Tonic Day 2026?**
-International Gin and Tonic Day is Monday 19 October 2026. Monday is usually a quiet night, which is exactly why a G&T board and a local gin spotlight earn their keep.
+**What national drinks days can a pub run through the year?**
+Plenty, and you only need a few. The easy autumn run is National Vodka Day (4 October), International Gin and Tonic Day (19 October) and Champagne Day (the fourth Friday of October, 23 October 2026). Earlier in the year there's World Gin Day (the second Saturday of June), National Beer Day or Beer Day Britain (15 June), National Prosecco Day (13 August) and World Cocktail Day (13 May). Pick the ones that suit your crowd rather than chasing all of them.
+
+**When is World Gin Day 2026?**
+World Gin Day falls on the second Saturday of June, which is 13 June 2026. Being a Saturday it suits a proper gin board and a local distillery spotlight, where International Gin and Tonic Day on 19 October is better as a quiet-Monday lift.
+
+**When is National Beer Day 2026?**
+National Beer Day in Britain, also called Beer Day Britain, is 15 June every year, which in 2026 is a Monday. It's tied to the sealing of Magna Carta and has a 7pm Cheers to Beer toast, so it's an easy excuse to feature a local cask or a guest beer.
 
 **When is Champagne Day 2026?**
 International Champagne Day falls on the fourth Friday of October, which is Friday 23 October 2026. Run it as a Champagne Weekend across Friday 23 and Saturday 24 October so you keep the Saturday trade too.

--- a/content/blog/national-drinks-days-pub-guide.md
+++ b/content/blog/national-drinks-days-pub-guide.md
@@ -2,6 +2,7 @@
 title: "National Vodka Day & Drinks Days: A Pub Calendar"
 slug: "national-drinks-days-pub-guide"
 publishedDate: 2026-05-25
+updatedDate: 2026-05-31
 excerpt: "A pub calendar of national drinks days to pick from, anchored by National Vodka Day. Pick a hook, run it in one shift, with serves, pricing and promotion that work."
 quickAnswer: "National Vodka Day is Sunday 4 October 2026, and it anchors a calendar of national drinks days a pub can pick from. The easy autumn run is National Vodka Day (4 Oct), International Gin and Tonic Day (19 Oct) and Champagne Day (the fourth Friday of October, 23 Oct 2026). Earlier in the year you've also got World Gin Day, National Beer Day, National Prosecco Day and World Cocktail Day. Each needs one featured serve, one chalkboard and one social post."
 author: "Peter Pitcher"
@@ -74,7 +75,7 @@ Here's the shortlist worth a pub's attention. Dates that move around are describ
 
 - **World Cocktail Day — Wednesday 13 May 2026.** The internationally recognised one (the UK also nods to National Cocktail Day on 24 March). A single signature cocktail on the board is plenty.
 - **World Gin Day — Saturday 13 June 2026** (the second Saturday of June). A Saturday, so it suits a proper gin board and a local distillery spotlight.
-- **National Beer Day — Monday 15 June 2026.** Also called Beer Day Britain, fixed to 15 June and tied to Magna Carta, with a 7pm Cheers to Beer toast. A gift if you keep cask.
+- **National Beer Day — Monday 15 June 2026.** Also called Beer Day Britain, fixed to 15 June and tied to Magna Carta, with a 7pm Cheers to Beer toast. A gift if you keep cask — and a natural warm-up for going bigger with your own beer festival come [Cask Ale Week](/licensees-guide/cask-ale-week-pub-guide) in September.
 - **National Prosecco Day — Thursday 13 August 2026.** High summer, fizz by the glass, garden weather. Easy yes for a treat.
 - **National Vodka Day — Sunday 4 October 2026.** Lands on a Sunday, so it rides alongside your roast trade. The pick of the bunch to start with.
 - **International Gin and Tonic Day — Monday 19 October 2026.** A quiet Monday, which is exactly why a G&T lift earns its keep.
@@ -123,7 +124,7 @@ International Champagne Day always falls on the fourth Friday of October, which 
 Fizz is the highest-margin pour on this list, and the one people most associate with "treating themselves," so it suits a weekend perfectly.
 
 - **Fizz by the glass.** The single most important move is making it available by the glass, not just the bottle. Most people won't commit to a full bottle on a whim, but a single glass to mark the occasion is an easy yes. That's where the volume is.
-- **A sparkling tasting.** A small, relaxed flight, two or three sparkling wines side by side with a card explaining each, gives people a reason to linger and order a second round. It doesn't need to be formal. A board, three small pours, a few lines of description.
+- **A sparkling tasting.** A small, relaxed flight, two or three sparkling wines side by side with a card explaining each, gives people a reason to linger and order a second round. It doesn't need to be formal. A board, three small pours, a few lines of description. It's the same format as a full [wine and cheese evening](/licensees-guide/wine-tasting-evenings-for-pubs), so if it flies you've already got the next event half-built.
 - **A premium treat.** Offer one genuinely nice option for the people who do want to push the boat out. An anniversary, a birthday, a Friday that's earned a celebration. Having something premium on the board gives that moment somewhere to land.
 
 A weekend gives the occasion room to breathe and means you're not relying on one night going well. If Friday is quiet, Saturday catches it.

--- a/content/blog/oktoberfest-pub-guide.md
+++ b/content/blog/oktoberfest-pub-guide.md
@@ -1,0 +1,194 @@
+---
+title: "Oktoberfest Ideas for Pubs: How to Host Your Own"
+slug: "oktoberfest-pub-guide"
+publishedDate: 2026-05-25
+excerpt: "A practical Oktoberfest plan for UK pubs: pick your weekend, get a festbier and steins on, lay out pretzels and bratwurst, cue the Oompah, and turn a quiet autumn night into repeat bookings."
+quickAnswer: "To host an Oktoberfest in your pub, pick any weekend across late September or early October, put a German festbier or wheat beer on, serve it in steins with a deposit, and lay on simple Bavarian food like pretzels and bratwurst. Add an Oompah playlist, blue-and-white decoration and long shared tables, push group bookings, and you've turned a dead autumn weekend into one of your busiest."
+author: "Peter Pitcher"
+category: "events"
+featuredImage: "/images/blog/oktoberfest-pub-guide.svg"
+tags:
+  - "oktoberfest"
+  - "oktoberfest ideas for pubs"
+  - "beer festival"
+  - "pub events"
+seasons:
+  - autumn
+occasions:
+  - oktoberfest
+status: "published"
+metaDescription: "Oktoberfest ideas for pubs: pick your weekend, get a festbier and steins on, serve pretzels and bratwurst, cue the Oompah, and fill a quiet autumn night."
+keywords:
+  - "oktoberfest"
+  - "oktoberfest ideas for pubs"
+  - "oktoberfest party ideas"
+  - "how to host an oktoberfest"
+  - "oktoberfest food ideas"
+hasFAQs: true
+hasQuickAnswer: true
+localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
+voiceSearchQueries:
+  - "when is oktoberfest 2026"
+  - "how do I host an oktoberfest in my pub"
+  - "what food do you serve at oktoberfest"
+  - "what beer do you serve at oktoberfest"
+faqs:
+  - question: "When is Oktoberfest 2026?"
+    answer: "The original Munich Oktoberfest runs Saturday 19 September to Sunday 4 October 2026. But you don't have to match those dates. A UK pub can run its own Oktoberfest on any weekend across late September or early October — pick whichever Friday-to-Sunday suits your trade and your calendar."
+  - question: "What beer do you serve at an Oktoberfest?"
+    answer: "Get a proper German-style beer on for the occasion. A festbier or Märzen is the traditional choice — golden, malty and very drinkable — or a cloudy wheat beer (Weissbier) for something a bit different. Serve it in steins for the theatre of it, and keep a familiar lager on too so nobody feels left out."
+  - question: "What food do you serve at an Oktoberfest?"
+    answer: "Keep it simple and Bavarian. Soft pretzels, bratwurst in a roll with mustard, currywurst, and a sharing board of cured meats, cheese and pickles will cover most of it. You don't need a full German menu — three or four crowd-pleasers done well beat a long list you can't execute on a busy night."
+  - question: "How do I host an Oktoberfest in my pub on a budget?"
+    answer: "You already own the room. Blue-and-white bunting, paper tablecloths, a free Oompah playlist and a chalkboard menu cost very little. The spend that matters is the beer and the food. Push group bookings and long shared tables so the room fills and feels like an event, and let the atmosphere do the rest."
+ctaSettings:
+  ctaType: "contact"
+  ctaHeading: "Want help turning Oktoberfest into a full weekend?"
+  ctaButtonText: "Book a Growth Fix"
+  ctaButtonLink: "/ways-to-work/growth-fix"
+schema:
+  "@context": "https://schema.org"
+  "@type": "Article"
+---
+
+# Oktoberfest Ideas for Pubs: How to Host Your Own
+
+*Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
+
+Late September is a funny old patch. The summer beer-garden crowd has gone home, Christmas is too far off to mention, and the diary's got that thin, quiet look about it. Which is exactly why Oktoberfest is one of the best ideas for pubs going. It's a ready-made theme, everyone already knows what it is, and it drops right into the deadest weekend of the autumn and gives people a reason to come out.
+
+And here's the bit a lot of licensees miss: you don't have to do anything fancy. Oktoberfest is a German beer festival that people already understand, so you're not selling a concept from scratch. Put a decent festbier on, lay out some pretzels and bratwurst, stick an Oompah playlist on, and you've got an event. The whole thing is theatre, and you already own the stage.
+
+**The original Munich Oktoberfest runs Saturday 19 September to Sunday 4 October 2026** — but you can run yours on any weekend across late September or early October. Pick whichever suits your trade.
+
+This guide is the practical version. No lederhosen lecture, no kit you don't already own. Just how to host an Oktoberfest that fills a quiet weekend and gives people a reason to book a table back in.
+
+## Why Oktoberfest works for a quiet UK autumn
+
+Most autumn problems come down to the same thing: no occasion. People will absolutely come to the pub in October — they just need a peg to hang the night on. Oktoberfest is that peg, and it's a brilliant one, because it carries its own atmosphere before you've done a single thing.
+
+A few reasons it punches above its weight:
+
+- **Everyone already gets it.** You don't have to explain Oktoberfest. Beer, steins, pretzels, a bit of Oompah — people picture the whole thing the second they read the word. That's half your marketing done for you.
+- **It's a group occasion.** Nobody does Oktoberfest alone. It pulls in stag-do energy, work nights out, friend groups and families — the kind of bookings that fill tables, not just barstools.
+- **It lands in a gap.** There's not much competing for the diary in late September. The chain down the road probably isn't bothering. A bit of theme and effort and you'll stand out a mile.
+- **It's a lead-in, not a one-off.** Run it well and you've got a roomful of people in a good mood, a fortnight before you start trailing your Christmas bookings. More on that at the end.
+
+At The Anchor we've learned the same lesson again and again: the quiet weeks aren't a footfall problem, they're an occasion problem. Give people a reason and they show up. Oktoberfest is one of the easiest reasons to give.
+
+## Picking your dates
+
+First decision, and it's an easy one. You are not bound to the Munich calendar. The festival over there is a sixteen-day epic; yours doesn't have to be. Pick the format that fits your pub.
+
+**A single weekend** is where most pubs should start. A Friday-to-Sunday is plenty — enough to build a bit of momentum, easy to staff, and you can throw everything at it without it dragging. If you've never done this before, do this.
+
+**A longer run** — say two weekends with the midweek in between — works if you've got the trade and the stock to sustain it. It gives you more bites at the cherry and lets people who missed the first weekend catch the second. But don't over-reach. A packed single weekend beats a thin ten days every time.
+
+One steer on timing: late September into the first weekend of October is the sweet spot. It rides the actual Oktoberfest publicity without clashing with Halloween at the end of the month. Look at your own diary, find the quietest weekend in that window, and that's your Oktoberfest.
+
+## The beer: get a proper German one on
+
+This is the heart of it. You can skimp on a lot, but not the beer. Oktoberfest is a beer festival — the drink is the reason people are there, so make it count.
+
+### What to put on
+
+You want at least one genuinely German-style beer that you don't normally have. The classic choices:
+
+- **Festbier or Märzen.** This is the real Oktoberfest beer — golden, malty, smooth and dangerously drinkable. If you put one thing on, put this on. It's the taste of the occasion.
+- **Weissbier (wheat beer).** Cloudy, fruity, served in the tall glass. A lovely contrast to the festbier and a talking point in its own right.
+
+Talk to your supplier early. Most can get you a German festbier or a recognisable wheat beer for the period, and a few weeks' notice makes all the difference. And keep a familiar lager on alongside it — not everyone wants to experiment, and you never want to send a round-buyer away empty-handed.
+
+### Steins and the Maß
+
+Here's where the theatre comes in. Serve the festbier in steins and the whole thing levels up. A litre stein — the Maß, as they call it in Munich — is a proper event in your hand, and it's what people will photograph.
+
+A word of practical advice: a Maß is a big, expensive glass, and they walk. Run a **stein deposit** — take a few pounds (or a card behind the bar) against each one, refunded when it comes back. It protects your glassware, it's completely normal at this kind of event, and it gives you a clean reason to chat to every table. If full litre steins are a stretch, a half-litre branded stein does the job and is easier to pour to line.
+
+## The food: keep it simple and Bavarian
+
+You do not need a full German menu. Trying to cook authentic Bavarian food across a busy weekend is how a good night turns into a kitchen meltdown. Pick three or four crowd-pleasers, do them well, and that's your Oktoberfest food sorted.
+
+The shortlist that does the heavy lifting:
+
+- **Soft pretzels.** The single most Oktoberfest thing you can put on a table. Warm, with mustard. Easy to buy in and finish off, low effort, big signal.
+- **Bratwurst in a roll.** A good German sausage, a soft roll, sweet or English mustard, maybe some fried onions. Simple, fast, exactly what people want.
+- **Currywurst.** Sliced sausage, curried ketchup, a shake of curry powder, chips on the side. A cult favourite and dead cheap to put out.
+- **A Bavarian sharing board.** Cured meats, a couple of cheeses, pickles, pretzel pieces, a pot of mustard. Made to order, ideal for the big group tables, and it makes a small spread look generous.
+
+That's a menu a normal pub kitchen can actually deliver on a heaving Saturday. Resist the urge to gold-plate it. If you want to think more broadly about how the food and drink work together on the night, our guide to [pub drinks menu design](/licensees-guide/pub-drinks-menu-design-guide) covers laying it out so it sells itself.
+
+## Music, decoration and atmosphere
+
+This is the cheap bit, and it's where a normal pub becomes an Oktoberfest. None of it needs a budget — it needs a bit of effort the week before.
+
+**The Oompah playlist.** Stick a Bavarian Oompah playlist on (the streaming services have them ready-made) and play it loud enough to be felt. It changes the whole feel of the room the moment people walk in. If you can rope in any live music for a couple of hours on the Saturday, even better, but a playlist alone does most of the work.
+
+**Blue and white, everywhere.** The Bavarian colours are your whole look. Blue-and-white bunting, chequered paper tablecloths, a few flags, balloons if you're feeling it. It's bunting and tablecloths — it costs very little and reads instantly as Oktoberfest. Chalk a big "Willkommen" by the door and you're there.
+
+**A chalkboard menu.** Write up your festbier, your wheat beer and your food specials on a board, German-style. It looks the part and it sells the offer to everyone who walks past.
+
+Don't agonise over authenticity. Nobody's marking you on it. The point is that someone steps through the door, hears the Oompah, sees the blue and white, and grins. That grin is the whole job done.
+
+## Make it social: long tables and group bookings
+
+Here's the move that turns a themed night into a properly busy one. Oktoberfest, done right, is a *shared* occasion — and the way you lay out the room decides whether that happens.
+
+**Long shared tables.** If you can, push tables together into long benches the way they do in the beer halls. Strangers end up elbow to elbow, groups merge, and the room feels full and buzzy even before it's packed. It's a completely different energy to scattered tables for two, and it's the single biggest thing you can do to make the night feel like an event.
+
+**Chase the group bookings.** This is where the real money is. Work nights out, friend groups, birthday lot, the local sports team — Oktoberfest is the perfect excuse for all of them. Make it easy: offer to reserve a long table for groups of six or more, maybe with steins ready on arrival. Put the word out a few weeks ahead so it lands while people are still planning their October.
+
+**Prost toasts.** A round of "Prost!" — the German cheers — across the room every now and then is daft, free, and it bonds the place together. Get your staff to kick a couple off through the night. It's the kind of small thing people remember and talk about.
+
+A bit of stein-themed fun goes a long way too — a friendly "best stein hold" moment, that sort of thing — but keep it good-natured and keep it sensible. This is a beer festival, so the responsible-retailing basics matter more than usual, not less: keep Challenge 25 front of mind, watch for anyone who's had enough, and never let a theme become an excuse to drop the standards. A great night and a well-run bar are the same thing.
+
+## Photos and promotion
+
+Oktoberfest is the most photogenic night you'll run all autumn, so use it. The steins, the pretzels, the blue and white, a packed long table — it's all built to be shared, and that's free reach you'd be daft to waste.
+
+A simple promotion plan:
+
+- **Trail it for two or three weeks.** Don't rely on one post the day before. People plan their nights out further ahead than we like to think, especially the group bookings. Put it across your social, your community groups, and a message to anyone on your list.
+- **Photograph the set-up, not just the night.** Post the bunting going up, the first festbier poured, the food coming out. The build-up sells the night.
+- **Get a few good shots on the night itself.** A full long table mid-toast, a stein in hand, the pretzels. Post them while it's happening and the next day — it's your advert for next year and your nudge to everyone who missed it.
+- **Encourage your customers to tag you.** People love posting a stein photo. Make sure your handle's on the chalkboard so their reach becomes yours.
+
+If you'd like a hand getting the build-up right and turning it into bookings, that's exactly the sort of thing we help pubs with — see [how we work with pubs](/ways-to-work).
+
+## Turning the night into repeat bookings
+
+Here's the part most pubs leave on the table. A good Oktoberfest isn't the finish line — it's a roomful of happy people, in late September or early October, right before the run-up to Christmas kicks off. That's a gift if you use it.
+
+A few moves to make it stick:
+
+- **Capture who came.** Every group booking is a contact worth keeping. The lot who booked a long table for Oktoberfest are exactly the people to tell about your Christmas dates — and they're already in a booking frame of mind.
+- **Plant the Christmas seed on the night.** A little card on each table, a line from the staff, a mention on the chalkboard: "Loved tonight? Get your Christmas table in early." You'll never have a warmer audience for it.
+- **Line up the next reason.** Oktoberfest doesn't stand alone — it's one thread in a busy autumn that runs through Halloween, Bonfire Night and into December. If you sort the calendar properly, each event feeds the next instead of being a fresh scramble. The [full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) pulls the whole season together.
+- **Make it an annual fixture.** The pubs that win at this run the same event every year so it becomes a thing people wait for. Year two is always easier — you've got the photos, the suppliers and the regulars who already know to book.
+
+Oktoberfest also sits nicely alongside the other autumn drinks occasions. If you're leaning into beer this season, our guide to [Cask Ale Week](/licensees-guide/cask-ale-week-pub-guide) shows how to make your handpulls the hero, and our [national drinks days guide](/licensees-guide/national-drinks-days-pub-guide) maps out the other dated hooks worth building a night around.
+
+## Your first move
+
+Don't plan the whole festival. Plan the basics, and the night builds on itself.
+
+1. Pick your weekend — the quietest Friday-to-Sunday in late September or early October.
+2. Ring your supplier and get a German festbier (and a wheat beer if you can) lined up, plus steins and a deposit plan.
+3. Sort three or four bits of Bavarian food your kitchen can actually deliver on a busy night.
+4. Cue up an Oompah playlist, grab some blue-and-white bunting, and start trailing it — chasing those group bookings first.
+
+Do that, and you've turned the deadest weekend of the autumn into one people look forward to. Oktoberfest is the rare event that's easy to run, cheap to dress, and lands exactly when your diary needs it most. Get it on.
+
+## FAQs
+
+**When is Oktoberfest 2026?**
+The original Munich Oktoberfest runs Saturday 19 September to Sunday 4 October 2026. But you don't have to match those dates. A UK pub can run its own Oktoberfest on any weekend across late September or early October — pick whichever Friday-to-Sunday suits your trade and your calendar.
+
+**What beer do you serve at an Oktoberfest?**
+Get a proper German-style beer on for the occasion. A festbier or Märzen is the traditional choice — golden, malty and very drinkable — or a cloudy wheat beer (Weissbier) for something a bit different. Serve it in steins for the theatre of it, and keep a familiar lager on too so nobody feels left out.
+
+**What food do you serve at an Oktoberfest?**
+Keep it simple and Bavarian. Soft pretzels, bratwurst in a roll with mustard, currywurst, and a sharing board of cured meats, cheese and pickles will cover most of it. You don't need a full German menu — three or four crowd-pleasers done well beat a long list you can't execute on a busy night.
+
+**How do I host an Oktoberfest in my pub on a budget?**
+You already own the room. Blue-and-white bunting, paper tablecloths, a free Oompah playlist and a chalkboard menu cost very little. The spend that matters is the beer and the food. Push group bookings and long shared tables so the room fills and feels like an event, and let the atmosphere do the rest.

--- a/content/blog/pub-halloween-bonfire-night-events.md
+++ b/content/blog/pub-halloween-bonfire-night-events.md
@@ -1,40 +1,45 @@
 ---
-title: "Pub Bonfire Night & Halloween: Events That Actually Work"
+title: "Halloween Food & Party Ideas for Pubs (+ Bonfire Night)"
 slug: "pub-halloween-bonfire-night-events"
-publishedDate: 2025-09-29
-excerpt: "Practical Halloween and Bonfire Night event ideas for pubs. Themed quizzes, family-friendly daytime events, ticketed fireworks, and seasonal food tie-ins that drive real revenue."
-quickAnswer: "The best pub Halloween and Bonfire Night events are practical, not gimmicky. A themed quiz night, a family pumpkin afternoon, and a ticketed fireworks viewing with a bonfire menu can each add hundreds of pounds to a single weekend. Start promoting six weeks out, build a simple social media countdown, and focus on food and drink tie-ins that lift your average spend."
+publishedDate: 2026-05-25
+excerpt: "Halloween food ideas and party ideas for pubs that actually drive trade — themed menus, adult party nights, plus Bonfire Night events and food. Practical, profitable, and easy to run."
+quickAnswer: "The best Halloween food ideas for pubs are warming, shareable, and high-margin: loaded nachos, chilli in a bread bowl, toffee apples and dark cocktails with a bit of theatre. For Halloween party ideas, pair a themed quiz or a ticketed adult party night with that food, then carry the momentum into Bonfire Night with hot dogs, mulled cider and a fixed-price supper. Promote six weeks out and lean on the food to lift your average spend."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/pub-halloween-bonfire-night-events.svg"
 tags:
+  - "halloween food ideas"
+  - "halloween party ideas"
   - "pub halloween party"
-  - "pub bonfire night"
+  - "bonfire night events"
   - "pub autumn events"
-  - "seasonal pub events"
-  - "pub event ideas"
 seasons:
   - autumn
 occasions:
   - halloween
   - bonfire-night
 status: "published"
-metaDescription: "Practical Halloween and Bonfire Night event ideas for pubs. Themed quizzes, family daytime events, ticketed fireworks, and seasonal menus that actually drive revenue."
+metaDescription: "Halloween food ideas and party ideas for pubs — themed menus, adult party nights, plus Bonfire Night events and food. Practical, profitable, easy to run."
 keywords:
-  - "pub halloween party"
-  - "pub bonfire night"
-  - "pub autumn events"
-  - "halloween pub event ideas"
-  - "bonfire night pub"
+  - "halloween food ideas"
+  - "halloween party ideas"
+  - "adult halloween party ideas"
+  - "halloween bar ideas"
+  - "bonfire night events"
+  - "bonfire night food"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
-  - "what events should a pub run for Halloween?"
+  - "what are good halloween food ideas for a pub?"
+  - "halloween party ideas for adults at a pub"
+  - "what food should a pub serve for bonfire night?"
   - "how do I plan a bonfire night at my pub?"
-  - "pub halloween party ideas that work"
-  - "how to do a fireworks night at a pub"
 faqs:
+  - question: "What are the best Halloween food ideas for a pub?"
+    answer: "Keep it warming, shareable, and high-margin. Loaded nachos badged as 'witches' fingers', chilli served in a hollowed bread bowl, pumpkin soup, and toffee apples or sticky toffee pudding for afters all photograph well and cost pennies to dress up. Put one or two dark cocktails on the bar — a rum punch or a green apple sour with a bit of dry ice — and you lift the average spend without touching your kitchen prep much."
+  - question: "What are good Halloween party ideas for adults at a pub?"
+    answer: "A ticketed adult Halloween party night works best: charge a small entry fee, include a drink on arrival, and run a fancy dress competition with a bar tab as the prize so the winner spends it with you. Pair it with a Halloween cocktail menu and a themed quiz, and hold it on the nearest Friday or Saturday rather than midweek so people can actually turn up. Halloween 2026 falls on Saturday 31 October, which makes that weekend an easy one to build around."
   - question: "How far in advance should I promote a pub Halloween event?"
     answer: "Start six weeks before, around mid-September. Post a mark-your-calendar on social media, add the event to your Google Business Profile, and open ticket sales or bookings at least three weeks out. A countdown series on social media in the final two weeks builds urgency and fills late seats."
   - question: "Do I need a TEN for a pub bonfire night event?"
@@ -55,17 +60,19 @@ schema:
   "@type": "Article"
 ---
 
-# Pub Bonfire Night & Halloween: Events That Actually Work
+# Halloween Food & Party Ideas for Pubs (+ Bonfire Night)
 
-October and November are two of the most underused months in the pub calendar. Summer beer gardens have gone quiet, Christmas bookings have not started yet, and the weather is doing its best to keep people at home.
+*Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
-But here is the thing. Halloween and Bonfire Night are two of the few occasions in the entire year when people actively want a reason to go out. They want atmosphere. They want something to do. They want somewhere warm with good food and a decent drink.
+The best Halloween food ideas for a pub aren't a freezer full of novelty nonsense — they're warming, shareable plates you can dress up for pennies and sell at a proper margin. And the best Halloween party ideas aren't a wall of pound-shop cobwebs either. They're a reason to go out: a themed quiz, a daft fancy dress competition, a dark cocktail with a bit of theatre. Get the food and the party right and October stops being a dead month. Then Bonfire Night, a week later, gives you a second bite of the same crowd.
 
-If you give them that, they will come. And they will spend.
+That matters because October and November are two of the most underused months in the pub calendar. Summer beer gardens have gone quiet, Christmas bookings haven't started yet, and the weather's doing its best to keep people at home.
 
-At The Anchor in Stanwell Moor, our autumn events regularly fill the pub on nights that would otherwise be quiet. None of what we do is complicated. It is just planned properly and promoted early enough.
+But here's the thing. Halloween and Bonfire Night are two of the few occasions all year when people actively want a reason to go out. They want atmosphere. Somewhere warm, good food, a decent drink. Give them that and they'll come — and they'll spend.
 
-This guide covers exactly what works. No plastic skeletons from a pound shop. No events that cost more to run than they bring in. Just practical, profitable ideas you can adapt to your pub, your space, and your team.
+At The Anchor in Stanwell Moor, our autumn events regularly fill the pub on nights that would otherwise be quiet. None of it's complicated. It's just planned properly and promoted early enough.
+
+This guide covers what actually works. No plastic skeletons from a pound shop, no events that cost more to run than they bring in. Just practical, profitable ideas you can adapt to your pub, your space, and your team. We'll lead with the Halloween food and party side, then carry it through to Bonfire Night.
 
 ## Why autumn events matter more than you think
 
@@ -75,7 +82,22 @@ Halloween and Bonfire Night give you two natural anchor points. They are built-i
 
 Done well, a strong October and November also sets up your December. Customers who come for your Halloween quiz or Bonfire Night supper are the same people who will book your Christmas party if you ask them at the right moment.
 
-## Halloween events that actually fill your pub
+## Halloween food ideas that lift your spend
+
+Start with the food, because it's where the margin lives and it's the bit most pubs phone in. You don't need a separate Halloween menu printed up — you need three or four warming, shareable plates off your existing kitchen, badged with a daft name and a chalkboard.
+
+Here's what works without tying your kitchen in knots:
+
+- **"Witches' fingers" loaded nachos.** Your normal nachos, a sausage finger on top, a smear of red sauce. Costs pennies, photographs brilliantly, and people order it because of the name.
+- **Chilli in a hollowed bread bowl.** Batch-cook the chilli, hollow a cob, ladle it in. Warming, filling, high-margin, and it looks the part without any effort.
+- **Pumpkin soup in a mug.** Cheap to make, sells as a starter or a standalone, and ties straight into the season.
+- **Toffee apples and sticky toffee pudding** for afters. Traditional, expected, profitable. A toffee apple on every table as a bit of theatre costs next to nothing.
+
+The drinks are where you turn a meal into an occasion. One or two Halloween cocktails on the bar — a dark rum punch, or a green apple sour with a bit of dry ice — cost pennies to make, photograph well, and carry a premium. That's your Halloween bar ideas sorted: you don't need a cocktail list as long as your arm, you need two drinks people will queue up to photograph.
+
+The whole point of leading with food is that it does the quiet work. The drinks largely take care of themselves on a busy night. It's the plates that protect your margin and give people a reason to stay for another round.
+
+## Halloween party ideas that actually fill your pub
 
 ### The themed quiz night
 
@@ -118,9 +140,11 @@ Daytime trade in autumn is hard. Families are back into the school routine, the 
 
 Pumpkins, tea lights, newspaper, and a few bags of fun-size chocolate. You are looking at under fifty pounds for materials that can drive a full afternoon of covers.
 
-### The Halloween party night
+### The adult Halloween party night
 
-A full evening Halloween party works best if your pub has a younger or mixed-age crowd and if you have space for either a DJ or live music. Be honest about whether this suits your venue. A forced party night in a quiet village local can feel awkward and lose money.
+When people search for adult Halloween party ideas, this is the one they mean: a proper evening event for grown-ups, not a kids' afternoon with cobwebs. A full Halloween party night works best if your pub has a younger or mixed-age crowd and you have space for a DJ or live music. Be honest about whether it suits your venue — a forced party night in a quiet village local can feel awkward and lose money.
+
+One thing in your favour for 2026: **Halloween falls on Saturday 31 October**, so you can run the party on the night itself without dragging anyone out midweek. That doesn't happen every year, so make the most of it.
 
 **If it does suit you:**
 
@@ -133,9 +157,11 @@ A full evening Halloween party works best if your pub has a younger or mixed-age
 
 - Over-decorating to the point where it looks cheap. A few well-placed items beat a hundred pound shop purchases
 - Promising a DJ and then playing Spotify through a Bluetooth speaker. If you cannot afford proper entertainment, do not advertise it
-- Running it on Halloween night itself if that falls midweek. Move it to the nearest Friday or Saturday when people can actually come
+- In a year where Halloween lands midweek, do not cling to the date itself. Move it to the nearest Friday or Saturday when people can actually come. (You're fine in 2026 — it's a Saturday.)
 
 ## Bonfire Night events that work for pubs
+
+**Bonfire Night falls on Thursday 5 November 2026.** A weeknight, so the smart money runs the big event on the Saturday either side and treats the night itself as a warming midweek supper. Either way, bonfire night events live or die on the food and the atmosphere far more than on actual fireworks — which, as you'll see, most pubs are better off not hosting themselves.
 
 ### The ticketed fireworks viewing
 
@@ -158,9 +184,9 @@ If your pub is within sight of a local display, or within walking distance of on
 - A fire pit or chiminea in the beer garden creates genuine bonfire atmosphere without the safety complications
 - Indoor sparkler cakes for dessert. Yes, they exist, and they photograph brilliantly
 
-### The bonfire menu
+### Bonfire Night food: the menu that protects your margin
 
-Food is where the real margin lives on Bonfire Night. People expect and want warming, hearty food. This plays to a pub kitchen's strengths.
+Food is where the real margin lives on Bonfire Night. People expect and want warming, hearty food — and good bonfire night food plays straight to a pub kitchen's strengths.
 
 **Menu ideas that work:**
 
@@ -300,4 +326,29 @@ Halloween and Bonfire Night are two of the easiest revenue opportunities in the 
 
 Keep it practical, promote it early, and focus on the food and drink tie-ins that actually make you money. You do not need a haunted house or a professional fireworks display. You need a well-planned event, a decent menu, and six weeks of consistent promotion.
 
+Halloween and Bonfire Night are two threads in a busier autumn. If you're planning the whole run, [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) pulls September to November together — and [the Cask Ale Week plan](/licensees-guide/cask-ale-week-pub-guide) is a good companion piece for the same period.
+
 Start planning now. Your autumn is about to get a lot busier.
+
+## FAQs
+
+**What are the best Halloween food ideas for a pub?**
+Keep it warming, shareable, and high-margin. Loaded nachos badged as "witches' fingers", chilli served in a hollowed bread bowl, pumpkin soup, and toffee apples or sticky toffee pudding for afters all photograph well and cost pennies to dress up. Put one or two dark cocktails on the bar — a rum punch or a green apple sour with a bit of dry ice — and you lift the average spend without touching your kitchen prep much.
+
+**What are good Halloween party ideas for adults at a pub?**
+A ticketed adult Halloween party night works best: charge a small entry fee, include a drink on arrival, and run a fancy dress competition with a bar tab as the prize so the winner spends it with you. Pair it with a Halloween cocktail menu and a themed quiz, and hold it on the nearest Friday or Saturday rather than midweek so people can actually turn up. Halloween 2026 falls on Saturday 31 October, which makes that weekend an easy one to build around.
+
+**How far in advance should I promote a pub Halloween event?**
+Start six weeks before, around mid-September. Post a mark-your-calendar on social media, add the event to your Google Business Profile, and open ticket sales or bookings at least three weeks out. A countdown series on social media in the final two weeks builds urgency and fills late seats.
+
+**Do I need a TEN for a pub bonfire night event?**
+If you are selling alcohol within your existing licensed hours and on your licensed premises, you do not need a Temporary Event Notice. However, if you plan to extend hours, serve alcohol in an unlicensed outdoor area, or host the event off-site, you may need a TEN. Check with your local council at least four weeks in advance.
+
+**Can a pub legally have a bonfire or fireworks?**
+You need to check with your local council and fire service. Most urban pubs cannot safely host a live bonfire, but a fire pit or chiminea in a beer garden can create the atmosphere. For fireworks, you typically need a licensed display operator and public liability insurance. Many pubs find it easier to partner with a local fireworks display and host the after-party instead.
+
+**What food should a pub serve for bonfire night?**
+Think warming, shareable, and high-margin. Loaded hot dogs, chilli con carne with jacket potatoes, pulled pork buns, and soup in mugs all work well. Toffee apples, parkin, and sticky toffee pudding are traditional dessert options. A set bonfire menu at a fixed price simplifies kitchen ops and protects your margin.
+
+**How do I make a pub Halloween event family-friendly during the day?**
+Run a daytime session between midday and three in the afternoon, separate from any adult evening event. Pumpkin carving, a fancy dress parade with small prizes, and a simple treasure hunt around the pub keep children entertained. Serve a kids meal deal alongside your regular menu so parents spend on food and drinks while the children are occupied.

--- a/content/blog/pub-halloween-bonfire-night-events.md
+++ b/content/blog/pub-halloween-bonfire-night-events.md
@@ -2,6 +2,7 @@
 title: "Halloween Food & Party Ideas for Pubs (+ Bonfire Night)"
 slug: "pub-halloween-bonfire-night-events"
 publishedDate: 2026-05-25
+updatedDate: 2026-05-31
 excerpt: "Halloween food ideas and party ideas for pubs that actually drive trade — themed menus, adult party nights, plus Bonfire Night events and food. Practical, profitable, and easy to run."
 quickAnswer: "The best Halloween food ideas for pubs are warming, shareable, and high-margin: loaded nachos, chilli in a bread bowl, toffee apples and dark cocktails with a bit of theatre. For Halloween party ideas, pair a themed quiz or a ticketed adult party night with that food, then carry the momentum into Bonfire Night with hot dogs, mulled cider and a fixed-price supper. Promote six weeks out and lean on the food to lift your average spend."
 author: "Peter Pitcher"

--- a/content/blog/sober-october-low-no-alcohol-pubs.md
+++ b/content/blog/sober-october-low-no-alcohol-pubs.md
@@ -1,38 +1,43 @@
 ---
-title: "Sober October: Low and No Drinks That Actually Sell in Your Pub"
+title: "Non Alcoholic Beer & a Low/No Bar That Sells: Sober October"
 slug: "sober-october-low-no-alcohol-pubs"
 publishedDate: 2026-05-25
-excerpt: "How to build a low and no range that earns its space behind the bar, with staff scripts, pricing, food pairings and how to promote Sober October properly."
-quickAnswer: "Stock a tight low and no range (a beer, a cider or fizz, a proper mocktail, good softs), make it visible on the menu, and price it for the margin it deserves. Train staff to offer it naturally, lean into Sober October, then keep your best lines all year. It is incremental trade, not lost trade."
+excerpt: "Start with one cracking non alcoholic beer, then build a small alcohol free bar — low and no alcohol drinks, a non alcoholic drinks menu and mocktail menu ideas — that earns its space and sells through Sober October and beyond."
+quickAnswer: "Lead with one genuinely good non alcoholic beer, then build a small alcohol free bar around it: a cider or fizz, a proper mocktail, good softs. Put it on a non alcoholic drinks menu section, price it for the margin it deserves, and train staff to offer it naturally. Sober October gets people through the door; keep your best low and no alcohol drinks on all year and it becomes steady trade, not lost trade."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/sober-october-low-no-alcohol-pubs.svg"
 tags:
+  - "non alcoholic beer"
+  - "alcohol free bar"
   - "low and no alcohol"
   - "sober october"
-  - "alcohol free pub"
-  - "pub drinks"
 seasons:
   - autumn
 occasions: []
 status: "published"
-metaDescription: "Low and no alcohol drinks that actually sell in your pub. A tight range, staff scripts, pricing for margin, food pairings and how to promote Sober October."
+metaDescription: "Non alcoholic beer that sells in your pub, plus a small alcohol free bar: low and no alcohol drinks, a non alcoholic drinks menu and Sober October done right."
 keywords:
-  - "low and no alcohol drinks for pubs"
+  - "non alcoholic beer"
+  - "alcohol free bar"
+  - "low and no alcohol drinks"
+  - "non alcoholic drinks menu"
+  - "mocktail menu ideas"
   - "sober october pub ideas"
-  - "alcohol free drinks pub"
-  - "no and low pub range"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
-  - "what low and no drinks should a pub stock"
-  - "do alcohol free drinks make money in pubs"
+  - "what non alcoholic beer should a pub stock"
+  - "how do I set up an alcohol free bar in my pub"
+  - "do non alcoholic drinks make money in pubs"
+  - "what low and no alcohol drinks sell best"
   - "how to promote sober october in a pub"
-  - "what is zebra striping drinking"
 faqs:
-  - question: "What low and no drinks should a pub stock?"
-    answer: "Keep it tight: one good alcohol-free lager or beer, a cider or sparkling option, one proper mocktail you can make consistently, and a couple of grown-up soft drinks beyond the usual cola. Four or five well-chosen lines that you can serve well beat a fridge full of dusty cans nobody can find."
+  - question: "What is the best non alcoholic beer for a pub to stock?"
+    answer: "The best non alcoholic beer is one you'd happily drink yourself and can keep in stock — an alcohol-free lager or pale ale from a brand your drinkers recognise, served cold and on the menu like it matters. Start your alcohol free bar with one cracking AF beer, get the whole team to taste it, then build the cider, mocktail and softs around it once you see it sell."
+  - question: "What low and no alcohol drinks should a pub stock?"
+    answer: "Keep it tight: one good non alcoholic beer, a cider or sparkling option, one proper mocktail you can make consistently, and a couple of grown-up soft drinks beyond the usual cola. Four or five well-chosen lines that you can serve well beat a fridge full of dusty cans nobody can find."
   - question: "Do low and no alcohol drinks actually make money?"
     answer: "Yes, when you price them properly. Low and no drinks often carry a healthy margin, and they capture spend from drivers, moderators and people who would otherwise have one round and leave. The mistake is pricing them like a cheap soft drink and undervaluing what people are happy to pay for a quality alcohol-free pint."
   - question: "How do I promote Sober October without alienating my regular drinkers?"
@@ -41,7 +46,7 @@ faqs:
     answer: "Zebra striping is alternating between an alcoholic drink and an alcohol-free one across a session, so one full-strength, then one alcohol-free. It helps people pace themselves, stay out longer and spend more across the night, which is exactly why having a good low and no range behind the bar pays off."
 ctaSettings:
   ctaType: "contact"
-  ctaHeading: "Want a low and no range that sells?"
+  ctaHeading: "Want an alcohol free bar that actually sells?"
   ctaButtonText: "Book a Growth Fix"
   ctaButtonLink: "/ways-to-work/growth-fix"
 schema:
@@ -49,11 +54,13 @@ schema:
   "@type": "Article"
 ---
 
-# Sober October: Low and No Drinks That Actually Sell in Your Pub
+# Non Alcoholic Beer & a Low/No Bar That Sells: Your Sober October Plan
 
 *Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
-Let's clear one thing up before we start. Sober October isn't a threat to your wet sales. It's a month where a chunk of your customers are actively looking for a reason to come to the pub and not drink alcohol, and most pubs make it weirdly hard for them.
+Here's the move that turns Sober October from a worry into a winner: lead with a genuinely good non alcoholic beer, then build a small alcohol free bar around it. One AF pint someone would actually choose, a couple of low and no alcohol drinks alongside it, and a tidy menu so people can find them — that's the whole thing. Get that right and a month a lot of licensees dread becomes one that quietly adds trade.
+
+Because let's clear one thing up before we go further. Sober October isn't a threat to your wet sales. It's a month where a chunk of your customers are actively looking for a reason to come to the pub and not drink alcohol, and most pubs make it weirdly hard for them.
 
 That's a missed trick. Because the people reaching for a low or no drink aren't people who'd otherwise be propping up the bar all night. They're the designated driver who currently nurses one lime and soda and leaves early. The friend who's pacing themselves so they can stay for the whole round. The midweek guest who fancies a night out without the next-day fog. The younger crowd who simply drink less than we did at their age.
 
@@ -63,20 +70,22 @@ The numbers back this up. 45% of drinkers had a no- or low-alcohol drink in the 
 
 So this guide isn't about turning your pub into a juice bar. It's about building a small, smart low and no range that earns its space, then selling it like you mean it.
 
-## Build a small board that earns its place
+## Start your alcohol free bar with one great non alcoholic beer
+
+Your alcohol free bar doesn't start with fifteen lines. It starts with one. Get a single, genuinely good non alcoholic beer on properly — listed, priced and poured cold — and you've already done more than most pubs manage all month. Everything else builds out from that anchor.
 
 The single biggest mistake is range bloat. A fridge stuffed with fifteen alcohol-free options nobody can choose between is worse than four good ones, because your staff can't recommend them and your customers can't find them.
 
 Keep it tight. You're aiming for a handful of lines that cover the main occasions:
 
-- **A proper alcohol-free beer.** This is the non-negotiable. An AF lager or pale ale that you'd happily drink yourself. The category has come a long way; the days of the apologetic warm half are over.
+- **A proper non alcoholic beer.** This is the non-negotiable, and the line your whole alcohol free bar hangs off. An AF lager or pale ale that you'd happily drink yourself. The category has come a long way; the days of the apologetic warm half are over.
 - **A cider or a sparkling option.** Something for the people who don't drink beer. An alcohol-free cider, or a grown-up sparkling pressé you can serve in a wine glass so it doesn't feel like a kids' drink.
-- **One proper mocktail.** Not an afterthought. One signature alcohol-free cocktail you can make the same way every time, fast, even on a busy Friday. A virgin mojito or a spiced ginger and citrus number works well.
+- **One proper mocktail.** Not an afterthought. You don't need a book of mocktail menu ideas — you need one signature alcohol-free cocktail you can make the same way every time, fast, even on a busy Friday. A virgin mojito or a spiced ginger and citrus number works well, and you can always add a second once the first one's flying.
 - **Two or three grown-up softs.** Move beyond the standard cola and lemonade. A good ginger beer, an artisan tonic over ice with garnish, a quality sparkling elderflower. These cost pennies more and sell for a lot more.
 
 That's it. Five or six lines, chosen so your team can recommend any of them with a straight face.
 
-Then make them visible. This is where most pubs fall down. If your low and no options live only in the bottom of a fridge or in your staff's heads, they don't exist. Put them on the menu as their own little section. Give them a chalkboard line. A proper [pub drinks menu design](/licensees-guide/pub-drinks-menu-design-guide) treats low and no as a category worth choosing from, not a footnote for people who "aren't drinking".
+Then make them visible. This is where most pubs fall down. If your low and no options live only in the bottom of a fridge or in your staff's heads, they don't exist. Give them their own non alcoholic drinks menu section and a chalkboard line, so the choice is obvious before anyone has to ask. A proper [pub drinks menu design](/licensees-guide/pub-drinks-menu-design-guide) treats low and no as a category worth choosing from, not a footnote for people who "aren't drinking".
 
 ## Make pacing the easy choice
 
@@ -131,6 +140,8 @@ A few practical moves:
 
 Then, when November comes, don't pack it all away. The whole point of those Drinkaware numbers is that this is year-round behaviour now. Keep your best two or three lines on permanently, leave them on the menu, and you'll find drivers and moderators come to rely on you for it all year. October just gets people through the door; the habit is what pays off.
 
+And there's a natural follow-on waiting. Dry January is the same crowd, twice the volume — a whole month when half the country's at least curious about going alcohol-free. If your alcohol free bar is already bedded in by autumn, you walk into January ready instead of scrambling. We cover that one properly in the winter plans; for now, just don't dismantle in November what you'll only want to rebuild in January.
+
 If you want the wider seasonal context, this slots straight into [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) alongside your quizzes, Halloween and Bonfire Night plans.
 
 One quick note on doing it responsibly: an alcohol-free range sits nicely alongside good serving practice generally. Keep supporting sensible drinking, stick to Challenge 25 on anything age-restricted, and point anyone who's interested towards Drinkaware. It's the right thing to do, and it's exactly the welcoming, non-judgemental atmosphere that makes people choose your pub in the first place.
@@ -149,8 +160,11 @@ If you'd like a hand putting a low and no range together that actually sells, or
 
 ## FAQs
 
-**What low and no drinks should a pub stock?**
-Keep it tight: one good alcohol-free lager or beer, a cider or sparkling option, one proper mocktail you can make consistently, and a couple of grown-up soft drinks beyond the usual cola. Four or five well-chosen lines that you can serve well beat a fridge full of dusty cans nobody can find.
+**What is the best non alcoholic beer for a pub to stock?**
+The best non alcoholic beer is one you'd happily drink yourself and can keep in stock — an alcohol-free lager or pale ale from a brand your drinkers recognise, served cold and on the menu like it matters. Start your alcohol free bar with one cracking AF beer, get the whole team to taste it, then build the cider, mocktail and softs around it once you see it sell.
+
+**What low and no alcohol drinks should a pub stock?**
+Keep it tight: one good non alcoholic beer, a cider or sparkling option, one proper mocktail you can make consistently, and a couple of grown-up soft drinks beyond the usual cola. Four or five well-chosen lines that you can serve well beat a fridge full of dusty cans nobody can find.
 
 **Do low and no alcohol drinks actually make money?**
 Yes, when you price them properly. Low and no drinks often carry a healthy margin, and they capture spend from drivers, moderators and people who would otherwise have one round and leave. The mistake is pricing them like a cheap soft drink and undervaluing what people are happy to pay for a quality alcohol-free pint.

--- a/content/blog/sober-october-low-no-alcohol-pubs.md
+++ b/content/blog/sober-october-low-no-alcohol-pubs.md
@@ -2,6 +2,7 @@
 title: "Non Alcoholic Beer & a Low/No Bar That Sells: Sober October"
 slug: "sober-october-low-no-alcohol-pubs"
 publishedDate: 2026-05-25
+updatedDate: 2026-05-31
 excerpt: "Start with one cracking non alcoholic beer, then build a small alcohol free bar — low and no alcohol drinks, a non alcoholic drinks menu and mocktail menu ideas — that earns its space and sells through Sober October and beyond."
 quickAnswer: "Lead with one genuinely good non alcoholic beer, then build a small alcohol free bar around it: a cider or fizz, a proper mocktail, good softs. Put it on a non alcoholic drinks menu section, price it for the margin it deserves, and train staff to offer it naturally. Sober October gets people through the door; keep your best low and no alcohol drinks on all year and it becomes steady trade, not lost trade."
 author: "Peter Pitcher"
@@ -142,7 +143,7 @@ Then, when November comes, don't pack it all away. The whole point of those Drin
 
 And there's a natural follow-on waiting. Dry January is the same crowd, twice the volume — a whole month when half the country's at least curious about going alcohol-free. If your alcohol free bar is already bedded in by autumn, you walk into January ready instead of scrambling. We cover that one properly in the winter plans; for now, just don't dismantle in November what you'll only want to rebuild in January.
 
-If you want the wider seasonal context, this slots straight into [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) alongside your quizzes, Halloween and Bonfire Night plans.
+It pairs neatly with the rest of October's drinks calendar, too. The [national drinks days](/licensees-guide/national-drinks-days-pub-guide) — Vodka Day, Gin & Tonic Day, a Champagne weekend — all run through the same month, and a confident no/low alternative on each means the driver and the moderator get a proper version of the featured serve rather than a shrug. If you want the wider seasonal context, this slots straight into [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) alongside your quizzes, Halloween and Bonfire Night plans.
 
 One quick note on doing it responsibly: an alcohol-free range sits nicely alongside good serving practice generally. Keep supporting sensible drinking, stick to Challenge 25 on anything age-restricted, and point anyone who's interested towards Drinkaware. It's the right thing to do, and it's exactly the welcoming, non-judgemental atmosphere that makes people choose your pub in the first place.
 

--- a/content/blog/wine-tasting-evenings-for-pubs.md
+++ b/content/blog/wine-tasting-evenings-for-pubs.md
@@ -1,45 +1,49 @@
 ---
-title: "How to Run a Wine Tasting Evening in Your Pub (Without Overcomplicating It)"
+title: "Wine & Cheese Evening: How to Run One in Your Pub"
 slug: "wine-tasting-evenings-for-pubs"
 publishedDate: 2026-05-25
-excerpt: "A plain-English guide to running a pub wine tasting evening that sells more wine, from a simple £10 flight format to staff crib notes and repeat bookings."
-quickAnswer: "Run a pub wine tasting as three small tastes for around £10, ideally part-funded by a supplier. Keep it informal, give guests a scorecard, pair each wine with a small bite, and capture the next date before they leave. You do not need a sommelier, just a clear running order and confident staff."
+excerpt: "A plain-English guide to running a wine and cheese evening in your pub, from a simple £10 flight and pairing board to local cheese, staff crib notes and repeat bookings."
+quickAnswer: "A wine and cheese night pairs three small wine tastes with a simple cheese and charcuterie board for around £10 to £15 a head, ideally part-funded by your wine supplier. Keep it informal, give guests a scorecard, match each wine to a cheese, and take the next booking before they leave. You do not need a sommelier, just a clear running order, a decent board and confident staff."
 author: "Peter Pitcher"
 category: "events"
 featuredImage: "/images/blog/wine-tasting-evenings-for-pubs.svg"
 tags:
+  - "wine and cheese evening"
+  - "cheese and wine night"
   - "wine tasting evening"
-  - "pub wine sales"
-  - "wine tasting night"
   - "pub events"
 seasons:
   - autumn
   - winter
 occasions: []
 status: "published"
-metaDescription: "How to run a wine tasting evening in your pub without overcomplicating it. A simple £10 flight format, staff crib notes, food pairings and repeat bookings."
+metaDescription: "How to run a wine and cheese evening in your pub: a simple £10 flight, a cheese pairing board, local cheese, staff crib notes and repeat bookings."
 keywords:
-  - "wine tasting evening ideas for pubs"
-  - "how to run a wine tasting night"
-  - "pub wine tasting"
-  - "wine tasting event"
+  - "wine and cheese evening"
+  - "cheese and wine night"
+  - "wine tasting evening ideas"
+  - "how to host a wine tasting"
+  - "how to run a wine tasting"
+  - "gin tasting evening"
 hasFAQs: true
 hasQuickAnswer: true
 localSEO: {"localModifiers":["near me","local","in my area","UK"],"nearbyLandmarks":["London","Surrey","Staines"],"targetLocation":"United Kingdom"}
 voiceSearchQueries:
-  - "how do I run a wine tasting night in my pub"
-  - "how much should I charge for a wine tasting"
+  - "how do I run a wine and cheese night in my pub"
+  - "how much should I charge for a wine and cheese evening"
+  - "what cheese goes with what wine"
   - "how many wines for a pub wine tasting"
-  - "how to sell more wine in a pub"
 faqs:
-  - question: "How much should I charge for a pub wine tasting?"
-    answer: "Around £10 to £15 per person for three small tastes plus a bite to eat works well, and feels like an evening out rather than a sample. If a supplier part-funds the wine, you can keep the ticket low and still protect your margin. Include a discount voucher towards a bottle on the night to recover the rest."
+  - question: "How do I run a wine and cheese evening in my pub?"
+    answer: "Pair three small wine tastes with a simple cheese and charcuterie board, served as a flight people can compare side by side. Charge around £10 to £15 a head, get your wine supplier to part-fund the wine, give every guest a scorecard, and match each wine to one cheese so the pairing tells a little story. Take the next booking before the room empties."
+  - question: "How much should I charge for a wine and cheese night?"
+    answer: "Around £10 to £15 per person for three small wine tastes plus a cheese board works well, and feels like an evening out rather than a sample. If your supplier part-funds the wine, you can keep the ticket low and still protect your margin. Add a discount voucher towards a bottle on the night to recover the rest."
+  - question: "What cheese goes with what wine?"
+    answer: "Keep it simple. A crisp white loves a soft, tangy goat's cheese; a juicy easy red goes with a mild cheddar or a slice of charcuterie; a big, fuller red stands up to a strong blue or a hard, aged cheddar. Match weight with weight, put the lightest pairing first, and a square of dark chocolate finishes the board nicely with the biggest red."
   - question: "How many wines should a tasting include?"
     answer: "Three is the sweet spot for a relaxed pub night, served as a flight of small pours people can compare side by side. Five is the most you should attempt without it dragging or palates tiring. Always leave room for guests to buy a full glass or bottle of their favourite afterwards."
-  - question: "Do I need a sommelier to run a wine tasting?"
-    answer: "No. You need a clear running order and someone confident enough to talk for a couple of minutes about each wine, which is something most reps will happily coach you on. A short crib sheet of plain-English tasting words is plenty. Honest enthusiasm beats jargon every time."
-  - question: "How do I promote a wine tasting evening?"
-    answer: "Start three to four weeks out across your own social media, local community groups and your customer database, and sell tickets so people commit. Lean on the 'taste before you buy' angle, which is exactly what drinkers are looking for. A final push in the last few days fills the remaining seats."
+  - question: "Do I need a sommelier to host a wine tasting?"
+    answer: "No. You need a clear running order and someone confident enough to talk for a couple of minutes about each wine and cheese, which is something most reps will happily coach you on. A short crib sheet of plain-English tasting words is plenty. Honest enthusiasm beats jargon every time."
 ctaSettings:
   ctaType: "contact"
   ctaHeading: "Want help building your wine offer?"
@@ -50,25 +54,25 @@ schema:
   "@type": "Article"
 ---
 
-# How to Run a Wine Tasting Evening in Your Pub (Without Overcomplicating It)
+# Wine & Cheese Evening: How to Run One in Your Pub
 
 *Part of the [Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas) — a September-to-November plan for filling your pub.*
 
-Wine is the quiet underperformer behind most pub bars. The cellar work is sorted, the beer range gets all the attention, and the wine just sits there on a tired list, selling the same two house options to people who'd happily spend more if you gave them a reason to.
+A wine and cheese evening is one of the easiest ways to lift spend per head, fill a quiet midweek, and turn wine from the dusty afterthought behind your bar into something your regulars actually look forward to. Put a few good wines next to a proper cheese board, charge a fair ticket, and you've got a cheese and wine night that feels like an occasion without costing you a fortune to put on. And no, you don't need a sommelier, a white tablecloth, or a single bit of jargon.
 
-That reason is a wine tasting evening. Done simply, it's one of the easiest ways to lift spend per head, fill a quiet midweek night, and turn wine from an afterthought into something your regulars actually look forward to. And no, you don't need a sommelier, a white tablecloth, or a single bit of jargon.
+Wine is the quiet underperformer behind most pub bars. The cellar work is sorted, the beer range gets all the attention, and the wine just sits there on a tired list, selling the same two house options to people who'd happily spend more if you gave them a reason to. Cheese is the reason. It makes the wine make sense, it slows the drinking down, and it turns "a few samples" into a sit-down evening people will book a table for.
 
-This is the click-out guide from [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas). Autumn is the moment to fix your wine offer: you've got a refreshed list going in before the party season, the nights are drawing in, and people are back to wanting somewhere warm to sit with a proper glass of something.
+This is the click-out guide from [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas). Autumn is the moment to fix your wine offer: you've got a refreshed list going in before the party season, the nights are drawing in, and people are back to wanting somewhere warm to sit with a proper glass of something and a bit of cheese.
 
-## Why wine underperforms in most pubs
+## Why a wine and cheese night works when wine alone doesn't
 
 Two things hold pub wine back, and neither is the wine itself.
 
 The first is that it feels formal. Drinkers worry they'll pick "wrong", mispronounce something, or look daft in front of their mates, so they default to the house red and never trade up. The second is that the list is invisible. It's buried in a menu, printed too small, or stuck on a shelf nobody reads. If people can't see it and don't feel confident choosing from it, they won't.
 
-A tasting fixes both in one go. It takes the fear out of wine by making it social and a bit of fun, and it puts your range right in front of people in a way they can taste, not just squint at.
+Adding cheese fixes both, and adds a third pull on top. Cheese makes the night social and a bit indulgent, so the fear drops away. It puts your range right in front of people in a way they can taste, not just squint at. And it gives you a second thing to sell — a board people will happily pay for, on a night they'd otherwise be at home.
 
-There's a tailwind here too. The themes coming out of the London Wine Fair in May 2026, as reported by the Morning Advertiser, were all about lighter reds, rosé, cans and kegged wine, English wine, and local, sustainable sourcing, with "taste before you buy" running through the lot. Low and no wine is a growing category as well. In other words, drinkers want to try before they commit, and they're curious about what's in the glass. A tasting evening is exactly that instinct made into an event.
+There's a tailwind here too. The themes coming out of the London Wine Fair in May 2026, as reported by the Morning Advertiser, were all about lighter reds, rosé, cans and kegged wine, English wine, and local, sustainable sourcing, with "taste before you buy" running through the lot. Low and no wine is a growing category as well. In other words, drinkers want to try before they commit, and they're curious about what's in the glass. A wine and cheese evening is exactly that instinct made into an event.
 
 ## Make wine easy to choose
 
@@ -85,91 +89,115 @@ Before you run a single event, sort the everyday stuff. A tasting brings people 
 
 **Run a weekly staff pick.** One wine, chalked up, with a one-line reason: "Sarah's pick: juicy Spanish red, perfect with the burger." It gives staff something easy to recommend and gives customers permission to try something new. Rotate it weekly so regulars come back to see what's next.
 
-Get these basics right and your wine sales lift before you've even sold a tasting ticket.
+Get these basics right and your wine sales lift before you've even sold a ticket.
 
-## How to run a £10 wine flight night
+## How to host a wine tasting: the £10 flight format
 
-Here's the format we'd point any pub towards. It's deliberately simple, because the simple version is the one you'll actually run twice.
+Here's the format we'd point any pub towards. It's deliberately simple, because the simple version is the one you'll actually run twice. This is the wine half of the evening; the cheese board comes next, and the two run together.
 
-**The format.** Three small tastes, served as a flight, plus a scorecard. Pour around 50ml of each so people can compare them side by side without anyone falling off their stool. A flight of three contrasting wines, say a crisp white, a light red and something fuller, gives guests an easy story to follow.
+**The format.** Three small tastes, served as a flight, plus a scorecard. Pour around 50ml of each so people can compare them side by side without anyone falling off their stool. A flight of three contrasting wines, say a crisp white, a light red and something fuller, gives guests an easy story to follow — and a natural order to pair cheeses against.
 
 **The scorecard.** A single printed sheet with space to mark each wine out of five and scribble a word or two. It does three jobs: it gives people something to do, it sparks chat between tables, and it quietly tells you which wines to push afterwards.
 
 **Pricing and ticketing.** Charge around £10 to £15 a head and sell tickets in advance so people commit and you know your numbers. The trick is to get a supplier to part-fund the wine; most reps will happily provide stock, glassware and point-of-sale for the exposure, which lets you keep the ticket low and your margin healthy. Pop a "£3 off any bottle tonight" voucher on each scorecard and you'll recover plenty on the back of it.
 
-**Food pairings.** You don't need a tasting menu. A small bite with each wine is enough: a cube of cheese, a slice of charcuterie, a square of dark chocolate with the fuller red. It slows the drinking, lifts the experience, and nudges people towards ordering food.
-
 **The run-sheet.** Keep it on one page:
 
 1. Welcome and a glass of something easy as people arrive (15 mins)
-2. Wine one: pour, two minutes of patter, let them taste and score (10 mins)
-3. Wine two: same again (10 mins)
-4. Wine three: same again (10 mins)
+2. Wine one with its cheese: pour, two minutes of patter, let them taste and score (10 mins)
+3. Wine two with its cheese: same again (10 mins)
+4. Wine three with its cheese: same again (10 mins)
 5. Open the bar for full glasses and bottles, hand out vouchers, take the next booking (the rest of the night)
 
 **Staffing and timing.** One confident host to run the talking, plus your normal bar cover. Allow around an hour for the structured part, then let it roll into a normal evening where people buy the wines they liked. That after-party is where the real money lands.
 
 A responsible word while we're here: run your Challenge 25 policy exactly as any other night, serve each wine at the right temperature (whites and rosé properly chilled, reds cool rather than warm), and use clean, polished glassware. Good glasses make cheap wine taste better and make the whole thing feel like an occasion.
 
+## Build a simple cheese pairing board
+
+The cheese is what turns a tasting into an evening. You don't need a cheesemonger's counter or anything clever — three or four cheeses, a bit of charcuterie, and a few bits to go alongside. The job is to give each wine a partner that makes both taste better.
+
+The trick is matching weight with weight. A delicate wine gets a delicate cheese; a big wine gets something strong enough to stand up to it. Run them lightest to heaviest, the same order as your wine flight, and the pairings tell a little story as the night goes on.
+
+A board that mirrors a classic three-wine flight:
+
+- **Crisp white → soft goat's cheese.** The fresh acidity in the wine cuts through the tang of the cheese, and each makes the other taste cleaner. A safe, lovely opener.
+- **Juicy easy red → mild cheddar or charcuterie.** A crowd-pleaser pairing. A slice of salami or a wedge of decent cheddar sits happily with a soft, fruity red and asks nothing difficult of anyone.
+- **Big, warming red → strong blue or aged cheddar.** This is where it gets fun. A punchy blue or a sharp mature cheddar has the guts to match a full red, and a square of dark chocolate alongside the biggest wine finishes the board on a high.
+
+Round it out with crackers, a few grapes, some chutney or quince, and oatcakes for anyone avoiding wheat. Lay it out generously and it photographs beautifully, which does half your marketing for the next one.
+
+**Go local where you can.** A British cheese from a maker down the road is a genuine selling point and a story your staff can tell. "This blue's from a farm twenty minutes away" beats any label. Local cheese ties in neatly with the English wine your customers are already curious about, and it's the kind of detail the chain down the road simply can't be bothered with. Your regular wholesaler will carry plenty, but it's worth a call to a nearby dairy or farm shop — many will do a trade price and some will happily send someone along to talk about the cheese, the same way a wine rep would.
+
+**How to price the cheese.** Keep the maths simple. Work out what the board costs you per head, treble it, and you're in roughly the right place for a healthy margin (cheese and charcuterie carry well, so don't undersell it). You've got two easy ways to charge:
+
+- **Bundle it into the ticket.** Fold the board cost into your £10 to £15 price so guests get wine and cheese for one number. Cleaner to sell, and nobody's doing sums on the night.
+- **Sell boards on the side.** Keep the tasting ticket lean and offer sharing boards at £8 to £12 to add to the table. Good for groups, and the boards keep selling long after the structured bit ends.
+
+Either way, put a couple of cheese and charcuterie boards on your everyday menu afterwards. You've just proved people will buy them, so don't let that walk out the door with the empty glasses.
+
 ## Wine words made easy
 
 Your staff don't need a qualification. They need a handful of honest phrases they can say with a straight face. Print this, stick it by the till, and you're sorted:
 
 - **Tannin** is the dry, grippy feeling in big reds, like over-stewed tea. "This one's got a bit of grip to it."
-- **Body** is how heavy it feels in the mouth. Light, medium or full. "It's a fuller one, good with the steak."
-- **Crisp** means fresh and sharp, usually a white. "Crisp and clean, lovely cold."
+- **Body** is how heavy it feels in the mouth. Light, medium or full. "It's a fuller one, good with the strong cheese."
+- **Crisp** means fresh and sharp, usually a white. "Crisp and clean, lovely with the goat's cheese."
 - **Dry vs sweet** is just how much sugar you can taste. Most table wine is dry. "Bone dry, this one."
 - **Easy-drinking** is the most useful phrase you own. It means soft, no rough edges, hard to dislike. "It's just an easy Tuesday red."
 
-The golden rule: if a customer asks what a wine's like, answer in food. "It's great with the burger" or "have it with a curry" beats any tasting note. People understand their dinner far better than they understand wine.
+The golden rule: if a customer asks what a wine's like, answer in food. "It's great with the blue cheese" or "have it with a curry" beats any tasting note. People understand their dinner far better than they understand wine.
 
 ## Other premium serve moments
 
-A tasting doesn't have to stand alone. Autumn is full of drinks-led hooks you can hang a premium serve on, the same way you would a wine night:
+A wine and cheese night doesn't have to stand alone. Autumn is full of drinks-led hooks you can hang a premium serve on, the same way you would a wine evening:
 
 - **National Vodka Day** (4 October) for a small batch of proper martinis or a signature serve
-- **National Gin & Tonic Day** (mid-October) for a perfect serve flight, gin's answer to the wine flight
+- **A gin tasting evening** around International Gin & Tonic Day (19 October) — a perfect-serve flight is gin's answer to the wine flight, and it runs on exactly the same format: three contrasting gins, a scorecard, a garnish each, and a supplier glad to part-fund it
 - **Champagne Friday or a Fizz Weekend** heading into party-booking season, when people are already in the mood to treat themselves
 
 You'll find the full calendar of these in [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas). The point is the same throughout: give people a reason to trade up from the usual, and most of them happily will.
 
 ## Turning a tasting into repeat bookings
 
-A one-off tasting is a nice night. A tasting that feeds your diary is a business asset. The difference is what you do in the last ten minutes.
+A one-off night is nice. A wine and cheese evening that feeds your diary is a business asset. The difference is what you do in the last ten minutes.
 
-**Capture the next date.** Before anyone leaves, announce the next tasting and take bookings on the spot. "Same night next month, the theme's English wine, who's in?" A half-full room signs up there and then.
+**Capture the next date.** Before anyone leaves, announce the next one and take bookings on the spot. "Same night next month, the theme's English wine and local cheese, who's in?" A half-full room signs up there and then.
 
-**Sell gift vouchers.** A wine tasting for two makes an easy, low-faff gift, and it's pre-paid trade that pulls new faces through your door. Have a few ready behind the bar, especially as Christmas nears.
+**Sell gift vouchers.** A wine and cheese night for two makes an easy, low-faff gift, and it's pre-paid trade that pulls new faces through your door. Have a few ready behind the bar, especially as Christmas nears.
 
 **Upsell the Christmas party.** The people at your tasting are exactly the ones who'll book a festive table. Ask them while they're relaxed and happy: "We do a cracking Christmas menu, shall I put your name down for a date?" Warm room, warm ask, easy yes.
 
 This is the same habit that turns any pub event into a fixture. We talk about it across the events guides, and it works because the next booking is always easiest to get from someone who's enjoying the current one.
 
-At The Anchor in Stanwell Moor, the events that became fixtures are the ones where we got the next date in the diary before the room emptied. Wine tastings are no different.
+At The Anchor in Stanwell Moor, the events that became fixtures are the ones where we got the next date in the diary before the room emptied. Wine and cheese nights are no different.
 
 ## Your first move
 
-Don't plan a wine programme. Plan one tasting.
+Don't plan a wine programme. Plan one evening.
 
-1. Ring your wine rep this week and ask what they'll part-fund for a tasting evening.
-2. Pick three contrasting wines, a quiet midweek night, and a small bite for each.
-3. Set a ticket price around £10 to £15 and start promoting three weeks out.
-4. Run it, take the next booking before everyone leaves, and tidy up your everyday wine list while it's fresh in your mind.
+1. Ring your wine rep this week and ask what they'll part-fund for a wine and cheese evening.
+2. Pick three contrasting wines, a cheese to partner each, and a quiet midweek night.
+3. Set a ticket price around £10 to £15 (board included), and start promoting three weeks out on the "taste before you buy" angle.
+4. Run it, take the next booking before everyone leaves, and tidy up your everyday wine list and cheese boards while it's fresh in your mind.
 
 Do that once and you'll wonder why wine ever sat quiet behind your bar.
 
-If you'd like a hand building a wine offer that actually sells, or turning a one-off tasting into a regular earner, that's the kind of thing we help with at Orange Jelly. Have a look at [how we work with pubs](/ways-to-work).
+If you'd like a hand building a wine offer that actually sells, or turning a one-off night into a regular earner, that's the kind of thing we help with at Orange Jelly. Have a look at [how we work with pubs](/ways-to-work).
 
 ## FAQs
 
-**How much should I charge for a pub wine tasting?**
-Around £10 to £15 per person for three small tastes plus a bite to eat works well, and feels like an evening out rather than a sample. If a supplier part-funds the wine, you can keep the ticket low and still protect your margin. Include a discount voucher towards a bottle on the night to recover the rest.
+**How do I run a wine and cheese evening in my pub?**
+Pair three small wine tastes with a simple cheese and charcuterie board, served as a flight people can compare side by side. Charge around £10 to £15 a head, get your wine supplier to part-fund the wine, give every guest a scorecard, and match each wine to one cheese so the pairing tells a little story. Take the next booking before the room empties.
+
+**How much should I charge for a wine and cheese night?**
+Around £10 to £15 per person for three small wine tastes plus a cheese board works well, and feels like an evening out rather than a sample. If your supplier part-funds the wine, you can keep the ticket low and still protect your margin. Add a discount voucher towards a bottle on the night to recover the rest.
+
+**What cheese goes with what wine?**
+Keep it simple. A crisp white loves a soft, tangy goat's cheese; a juicy easy red goes with a mild cheddar or a slice of charcuterie; a big, fuller red stands up to a strong blue or a hard, aged cheddar. Match weight with weight, put the lightest pairing first, and a square of dark chocolate finishes the board nicely with the biggest red.
 
 **How many wines should a tasting include?**
 Three is the sweet spot for a relaxed pub night, served as a flight of small pours people can compare side by side. Five is the most you should attempt without it dragging or palates tiring. Always leave room for guests to buy a full glass or bottle of their favourite afterwards.
 
-**Do I need a sommelier to run a wine tasting?**
-No. You need a clear running order and someone confident enough to talk for a couple of minutes about each wine, which is something most reps will happily coach you on. A short crib sheet of plain-English tasting words is plenty. Honest enthusiasm beats jargon every time.
-
-**How do I promote a wine tasting evening?**
-Start three to four weeks out across your own social media, local community groups and your customer database, and sell tickets so people commit. Lean on the "taste before you buy" angle, which is exactly what drinkers are looking for. A final push in the last few days fills the remaining seats.
+**Do I need a sommelier to host a wine tasting?**
+No. You need a clear running order and someone confident enough to talk for a couple of minutes about each wine and cheese, which is something most reps will happily coach you on. A short crib sheet of plain-English tasting words is plenty. Honest enthusiasm beats jargon every time.

--- a/content/blog/wine-tasting-evenings-for-pubs.md
+++ b/content/blog/wine-tasting-evenings-for-pubs.md
@@ -2,6 +2,7 @@
 title: "Wine & Cheese Evening: How to Run One in Your Pub"
 slug: "wine-tasting-evenings-for-pubs"
 publishedDate: 2026-05-25
+updatedDate: 2026-05-31
 excerpt: "A plain-English guide to running a wine and cheese evening in your pub, from a simple £10 flight and pairing board to local cheese, staff crib notes and repeat bookings."
 quickAnswer: "A wine and cheese night pairs three small wine tastes with a simple cheese and charcuterie board for around £10 to £15 a head, ideally part-funded by your wine supplier. Keep it informal, give guests a scorecard, match each wine to a cheese, and take the next booking before they leave. You do not need a sommelier, just a clear running order, a decent board and confident staff."
 author: "Peter Pitcher"
@@ -150,13 +151,13 @@ The golden rule: if a customer asks what a wine's like, answer in food. "It's gr
 
 ## Other premium serve moments
 
-A wine and cheese night doesn't have to stand alone. Autumn is full of drinks-led hooks you can hang a premium serve on, the same way you would a wine evening:
+A wine and cheese night doesn't have to stand alone. Autumn is full of drinks-led hooks you can hang a premium serve on, the same way you would a wine evening. These are the [national drinks days](/licensees-guide/national-drinks-days-pub-guide) worth a look — each one a single featured serve rather than a whole event:
 
 - **National Vodka Day** (4 October) for a small batch of proper martinis or a signature serve
 - **A gin tasting evening** around International Gin & Tonic Day (19 October) — a perfect-serve flight is gin's answer to the wine flight, and it runs on exactly the same format: three contrasting gins, a scorecard, a garnish each, and a supplier glad to part-fund it
 - **Champagne Friday or a Fizz Weekend** heading into party-booking season, when people are already in the mood to treat themselves
 
-You'll find the full calendar of these in [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas). The point is the same throughout: give people a reason to trade up from the usual, and most of them happily will.
+And don't forget the ones drinking less. A good alcohol-free pour deserves the same care as a fine wine, so it's worth reading your wine evening alongside our [Sober October low-and-no guide](/licensees-guide/sober-october-low-no-alcohol-pubs) — a confident no/low option means nobody at the table feels left out of the occasion. You'll find the full calendar of all this in [the full Autumn Pub Playbook](/licensees-guide/autumn-pub-event-ideas). The point is the same throughout: give people a reason to trade up from the usual, and most of them happily will.
 
 ## Turning a tasting into repeat bookings
 

--- a/docs/greene-king-toolkit/autumn-2026-keyword-plan.md
+++ b/docs/greene-king-toolkit/autumn-2026-keyword-plan.md
@@ -1,0 +1,106 @@
+# Autumn Pub Playbook — Keyword Plan (2026)
+
+**Research:** 3 rounds via Google Keyword Planner, location United Kingdom, Historical metrics May 2025 – Apr 2026.
+**Audience/intent:** B2B — pub operators/licensees looking for ideas (the `/licensees-guide/` reader), not consumers looking for a pub.
+
+> **Volume caveat:** Keyword Planner reports in broad buckets (50 / 500 / 5,000 / 50,000). Treat these as *relative tiers*, not precise figures. Many autumn terms are highly seasonal (the annual average understates the Sept–Nov peak).
+
+---
+
+## Headline findings
+
+1. **Operator long-tail is a dead end.** "autumn pub event ideas", "how to boost pub trade in autumn", "creative pub event ideas", "seasonal pub marketing ideas", "key trading dates for pubs", "drinks calendar for pubs" — **all returned no data.** Build on parent heads + occasion names instead.
+2. **"pub event ideas" (500, Low) is the hub primary** — and orangejelly.co.uk already ranks for the *summer* variant, so the pattern works.
+3. **Two strong pages are MISSING:** **Oktoberfest** (`oktoberfest` = 50,000, Low) and **Halloween** (`halloween food ideas` = 5,000, Low; `halloween party ideas` = 5,000). Both are calendar-only today.
+4. **The Black Friday spoke should pivot to GIFTING.** Every "black friday pub" phrase = zero; "gift vouchers for pubs" (500) and "pub gift card" (500) are real.
+5. **The autumn-rugby spoke is weak for B2B SEO** — its volume is all consumer fixture-finding ("rugby on tv" 50,000, "autumn internationals rugby" 5,000, "where to watch rugby" 5,000), not operator advice.
+
+---
+
+## Cluster-level plan (skill format)
+
+### Primary keywords
+- pub event ideas (500, Low)
+- oktoberfest (50,000, Low) — *needs a page*
+- beer festival (5,000, Low)
+- non alcoholic beer (5,000, Low)
+- halloween food ideas (5,000, Low) — *needs a page*
+- coffee morning ideas (500, Low)
+- wine and cheese evening / cheese and wine night (500, Medium)
+- cask ale week (500, Low) + real ale festival (500, Low)
+- national vodka day (500, Low)
+
+### Secondary keywords
+- pub entertainment ideas (50, Low), bar event ideas (50, Low), pub promotion ideas (50, Low)
+- pub marketing (50, Low — **£6–15 top bid**, buyer intent), pub marketing agency (50, Low)
+- alcohol free bar (500), low and no alcohol drinks (50), non alcoholic drinks menu (50), mocktail menu ideas (50)
+- charity fundraising ideas (5,000, Med), macmillan coffee morning ideas (500), fundraising ideas for pubs (50)
+- world gin day (500), national beer day (500), national cocktail day (500), national prosecco day (500)
+- gift vouchers for pubs (500), pub gift card (500), christmas gift vouchers (500)
+- craft beer festival (500), beer festival ideas (50), meet the brewer event (50)
+- adult halloween party ideas (500), bonfire night events (500), bonfire night food (5,000)
+- pub quiz ideas (500), how to host a wine tasting (50), how to run a pub quiz (50)
+
+### Local SEO keywords
+**Deliberately minimal.** This is national B2B advice content, so "[town] pub" terms are consumer intent and don't fit the licensee guide. Orange Jelly's local angle belongs on its commercial/service pages, not the playbook. If a local layer is ever wanted, the only candidate with any logic is `pub marketing agency [county]` — but volume is negligible.
+
+---
+
+## Page-by-page mapping
+
+### Hub — Autumn Pub Playbook · `/licensees-guide/autumn-pub-event-ideas`
+- **Primary:** pub event ideas (500, Low)
+- **Secondary:** pub entertainment ideas, bar event ideas, pub promotion ideas, seasonal pub marketing ideas, pub marketing (high buyer value)
+- **Action:** lead the title/H1 with "Pub Event Ideas" framed for autumn; keep "autumn events" (500, consumer) as a light supporting term only.
+
+### Spoke — Wine tasting · `wine-tasting-evenings-for-pubs`
+- **Primary:** wine and cheese evening / cheese and wine night (500 each, Med) — **10× "wine tasting night" (50)**
+- **Secondary:** wine tasting evening ideas (50), how to host a wine tasting (50), how to run a wine tasting (50), gin tasting evening (50)
+- **Action:** widen the page to "wine **and cheese** evenings", not wine tasting alone.
+
+### Spoke — Sober October / low & no · `sober-october-low-no-alcohol-pubs`
+- **Primary:** non alcoholic beer (5,000, Low) + sober october (5,000, seasonal)
+- **Secondary:** alcohol free bar (500), low and no alcohol drinks (50), non alcoholic drinks menu (50), mocktail menu ideas (50)
+- **Action:** product-led ("a non-alcoholic beer/range that earns its place") under the Sober October hook.
+
+### Spoke — Cask Ale Week → Beer festival · `cask-ale-week-pub-guide`
+- **Primary:** beer festival (5,000, Low)
+- **Secondary:** cask ale week (500), real ale festival (500), craft beer festival (500), beer festival ideas (50), meet the brewer event (50), tap takeover (50)
+- **Action:** broaden the framing to "beer festival / cask ale" so it captures the 5,000 head.
+
+### Spoke — Macmillan Coffee Morning · `macmillan-coffee-morning-pub-guide`
+- **Primary:** coffee morning ideas (500, Low — winnable) beneath the giant "macmillan coffee morning" (50,000) head
+- **Secondary:** macmillan coffee morning ideas (500), charity fundraising ideas (5,000), fundraising ideas for pubs (50), charity event ideas for pubs (50)
+- **Action:** target "coffee morning ideas" and broaden toward pub fundraising.
+
+### Spoke — National drinks days · `national-drinks-days-pub-guide`
+- **Primary:** national vodka day (500) anchoring a cluster
+- **Secondary:** world gin day (500), national beer day (500), national cocktail day (500), national prosecco day (500), national drinks days (50), international champagne day (50)
+- **Action:** present as a "national [drink] day" calendar of hooks.
+
+### Spoke — Autumn rugby · `autumn-rugby-nations-championship-pubs` ⚠️
+- **Verdict:** weak B2B SEO target. Volume is consumer fixture-finding (rugby on tv 50,000; autumn internationals rugby 5,000; where to watch rugby 5,000). The operator-advice angle has ~no search.
+- **Options:** (a) keep for playbook completeness, optimise lightly for "autumn internationals", expect little organic; (b) reframe consumer-facing "where to watch the autumn internationals" — off-brand for the licensee guide; (c) fold into the hub.
+- **Recommendation:** (a) — keep it, light "autumn internationals" optimisation, low organic expectations.
+
+### Spoke — Black Friday → GIFTING · `black-friday-pub-ideas`
+- **Primary:** gift vouchers for pubs (500) + pub gift card (500)
+- **Secondary:** christmas gift vouchers (500), gift vouchers for restaurants (5,000, High)
+- **Action:** **pivot the page from "Black Friday" (zero search) to gift cards & vouchers.** Black Friday is the *date hook*; "gift vouchers" is the *search term*.
+
+---
+
+## Recommended NEW pages (strong data)
+
+1. **Oktoberfest for pubs** — `oktoberfest` **50,000, Low**, plus oktoberfest ideas (50), oktoberfest party ideas (50), how to host an oktoberfest (50). **The single biggest autumn opportunity, and it's absent.** Add to the hub calendar (mid–late Sept/early Oct) and as a spoke.
+2. **Halloween at your pub** — halloween food ideas (5,000, Low), halloween party ideas (5,000), adult halloween party ideas (500), halloween bar ideas (50). Currently calendar-only; the low-competition "food ideas" angle is very winnable.
+
+**Beyond autumn (flagged for the roadmap):**
+- **Pub quiz guide** — pub quiz questions (50,000, Low), pub quiz ideas (500), how to run a pub quiz (50). Huge evergreen vertical.
+- **Bonfire Night** — bonfire night events (500), bonfire night food (5,000). Pairs naturally with Halloween.
+
+---
+
+## Rationale
+
+The autumn cluster's organic upside sits in two layers: a small set of **evergreen operator heads** ("pub event ideas", "pub entertainment ideas") for the hub, and a larger set of **occasion names** (Oktoberfest, beer festival, non-alcoholic beer, coffee morning, wine & cheese, the national drinks days) for the spokes — captured by naming the occasion plainly and adding the "ideas / for pubs" operator angle. The biggest wins are *structural*, not on-page: adding an Oktoberfest page (50k, low competition) and a Halloween page (5k, low competition), and re-pointing the Black Friday spoke at the gifting terms people actually search. Rugby is the one weak spot — keep it for completeness but don't expect it to earn search.

--- a/public/images/blog/oktoberfest-pub-guide.svg
+++ b/public/images/blog/oktoberfest-pub-guide.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Oktoberfest for Pubs — Orange Jelly">
+  <rect width="1200" height="630" fill="#EA580C"/>
+  <rect x="0" y="0" width="1200" height="8" fill="#006064"/>
+  <rect x="0" y="622" width="1200" height="8" fill="#006064"/>
+  <text x="600" y="300" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="92" font-weight="700" fill="#FFFFFF">Oktoberfest</text>
+  <text x="600" y="368" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="34" fill="#FFFFFF" opacity="0.92">How to host your own in the pub</text>
+  <text x="600" y="560" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="26" letter-spacing="3" fill="#FFFFFF" opacity="0.85">ORANGE JELLY</text>
+</svg>

--- a/public/images/blog/pub-halloween-bonfire-night-events.svg
+++ b/public/images/blog/pub-halloween-bonfire-night-events.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Halloween Food & Party Ideas for Pubs — Orange Jelly">
+  <rect width="1200" height="630" fill="#EA580C"/>
+  <rect x="0" y="0" width="1200" height="8" fill="#006064"/>
+  <rect x="0" y="622" width="1200" height="8" fill="#006064"/>
+  <text x="600" y="270" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="84" font-weight="700" fill="#FFFFFF">Halloween &amp; Bonfire</text>
+  <text x="600" y="356" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="84" font-weight="700" fill="#FFFFFF">Ideas for Pubs</text>
+  <text x="600" y="424" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="34" fill="#FFFFFF" opacity="0.92">Food, party nights &amp; menus that actually sell</text>
+  <text x="600" y="560" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="26" letter-spacing="3" fill="#FFFFFF" opacity="0.85">ORANGE JELLY</text>
+</svg>

--- a/src/components/blog/SeriesHubGrid.tsx
+++ b/src/components/blog/SeriesHubGrid.tsx
@@ -46,7 +46,7 @@ export default function SeriesHubGrid({
   posts,
   baseUrl,
   heading = 'The full Autumn Pub Playbook',
-  subtitle = 'Seven practical guides — pick the moments that fit your pub.',
+  subtitle = 'Practical guides — pick the moments that fit your pub.',
   listName = 'The Autumn Pub Playbook',
 }: SeriesHubGridProps) {
   if (!posts || posts.length === 0) return null;

--- a/src/lib/blog-images.ts
+++ b/src/lib/blog-images.ts
@@ -101,6 +101,7 @@ export function getDefaultBlogImage(slug: string): string {
     'wine-tasting-evenings-for-pubs': '/images/blog/wine-tasting-evenings-for-pubs.svg',
     'sober-october-low-no-alcohol-pubs': '/images/blog/sober-october-low-no-alcohol-pubs.svg',
     'cask-ale-week-pub-guide': '/images/blog/cask-ale-week-pub-guide.svg',
+    'oktoberfest-pub-guide': '/images/blog/oktoberfest-pub-guide.svg',
     'macmillan-coffee-morning-pub-guide': '/images/blog/macmillan-coffee-morning-pub-guide.svg',
     'national-drinks-days-pub-guide': '/images/blog/national-drinks-days-pub-guide.svg',
     'autumn-rugby-nations-championship-pubs':

--- a/src/lib/seasonal-hubs.ts
+++ b/src/lib/seasonal-hubs.ts
@@ -34,6 +34,11 @@ export const SEASON_HUBS: SeasonalHub[] = [
         opportunity: 'Beer of the day, cask passport, meet-the-brewer',
       },
       {
+        date: '19 Sep–4 Oct',
+        moment: 'Oktoberfest',
+        opportunity: 'Steins, pretzels and an Oompah night of your own',
+      },
+      {
         date: 'Fri 25 Sep',
         moment: 'Macmillan Coffee Morning',
         opportunity: 'A quiet daytime filled, and a good cause',
@@ -93,8 +98,10 @@ export const SEASON_HUBS: SeasonalHub[] = [
       'wine-tasting-evenings-for-pubs',
       'sober-october-low-no-alcohol-pubs',
       'cask-ale-week-pub-guide',
+      'oktoberfest-pub-guide',
       'macmillan-coffee-morning-pub-guide',
       'national-drinks-days-pub-guide',
+      'pub-halloween-bonfire-night-events',
       'autumn-rugby-nations-championship-pubs',
       'black-friday-pub-ideas',
     ],


### PR DESCRIPTION
## What changed
Implements the autumn-2026 keyword plan across the autumn cluster (10 pages) and applies fixes from an SEO quick-checkup.

- New: Oktoberfest pub guide (the high-volume, low-competition gap)
- 9 pages retargeted to researched primaries (hub to pub event ideas; wine to wine & cheese; sober october to non alcoholic beer; cask broadened to beer festival; macmillan to coffee morning ideas; black friday reframed to operator-intent bookings; halloween to food/party ideas; plus drinks days + light autumn rugby)
- Oktoberfest + the existing Halloween page wired into the hub (featuredGuides + calendar)
- SEO quick-checkup fixes: corrected a B2C intent mismatch on Black Friday, completed hub-to-spoke + sibling internal linking, added freshness dates
- Cask Ale Week 2026 dates hedged (not yet officially announced)

## Testing
typecheck, lint (British English + growth-language), and build all green. Editorial pipeline + 3-specialist SEO checkup run on the pages. All slugs/URLs preserved (on-page retargets only).

## Breaking changes / migration risk
None - content + config only, slugs preserved, fully revertable.

## Known follow-ups (NOT in this PR)
- OG images are SVG (blank social previews) - needs a dynamic opengraph-image PNG route, site-wide
- Connect GSC + GA4 before late August for a pre-season baseline