### PR TITLE
docs: autumn toolkit handover email to Charlotte

### DIFF
--- a/docs/greene-king-toolkit/autumn-2026-charlotte-email.md
+++ b/docs/greene-king-toolkit/autumn-2026-charlotte-email.md
@@ -1,0 +1,39 @@
+# Draft email to Charlotte Brown (Greene King) — Autumn toolkit handover
+
+**To:** Charlotte Brown, Head of Marketing (Leased & Tenanted), Greene King
+**From:** Peter Pitcher, Orange Jelly
+**Companion file:** `autumn-2026-toolkit-copy.md` (the A4 spread — attach/paste with this email)
+**Status:** Draft, ready to send ahead of the 8 June copy deadline.
+
+---
+
+**Subject:** Autumn toolkit copy — *The Autumn Pub Playbook* (in ahead of 8 June)
+
+Hi Charlotte,
+
+Here's the autumn toolkit copy, in nice and early ahead of the 8 June deadline. It's a one-to-two page A4 spread — *The Autumn Pub Playbook* — that your pubs can pick up and run with straight away. The copy's attached; here's the quick tour.
+
+**What it is.** Practical, from-the-cellar advice written in my own voice as a working licensee, with Orange Jelly as the sponsor. It takes a licensee through the autumn moments that genuinely fill a pub from September to November: Cask Ale Week, Oktoberfest, a low-and-no push for Sober October, a wine and cheese night, Halloween and Bonfire Night, the autumn rugby, and the early-Christmas gifting run — each with two or three things they can actually do, not a wish-list.
+
+**The QR code.** Each section points to the deeper how-to online. The single QR on the sheet should encode this shortlink — **l.the-anchor.pub/c0l05s** — which your agency can drop straight into the artwork. It lands pubs on **orangejelly.co.uk/autumn**: the full playbook.
+
+**The online content is already live.** Anyone scanning today gets the complete hub — nine in-depth guides plus a brand-new Oktoberfest playbook — so there's real substance behind the sheet from day one, not a "coming soon".
+
+**A couple of small checks against the brief.** I firmed up a few dates so we're spot-on for print: International Champagne Day is the fourth Friday of October (Friday 23 October this year), and I've framed the November rugby as the autumn internationals. I also swapped out one low/no figure I couldn't tie to a solid source — worth being careful with numbers going out to hundreds of pubs.
+
+**Christmas is teed up.** There's a short teaser at the end nudging pubs toward the Christmas toolkit, so this quarter rolls straight into the next.
+
+Two things to lock it in from your side:
+
+1. Your agency generating the QR from the shortlink above.
+2. A quick thumbs-up on the spread — any changes, send them over and I'll turn them round well before the early-August send.
+
+I'll make sure the shortlink carries the campaign tracking, so we can see exactly how many pubs scan through and what they read.
+
+Really pleased with this one, Charlotte. Looking forward to your thoughts.
+
+Best,
+Peter
+
+Peter Pitcher
+Orange Jelly · orangejelly.co.uk


### PR DESCRIPTION
Adds the covering email to accompany the A4 autumn toolkit copy (the 8 June Greene King deliverable). Doc-only — no code or routes touched; build verified green.