### PR TITLE
feat: autumn toolkit 2026 — seasonal hubs, content & clickable calendar dates

### DIFF
--- a/src/components/blog/SeasonalCalendar.tsx
+++ b/src/components/blog/SeasonalCalendar.tsx
@@ -1,4 +1,5 @@
 import { type CSSProperties } from 'react';
+import Link from 'next/link';
 import Grid from '@/components/Grid';
 import Heading from '@/components/Heading';
 import Text from '@/components/Text';
@@ -16,6 +17,10 @@ interface SeasonalCalendarProps {
  * table with a scannable, accessible grid of dated moments. Colour comes from the
  * season token set (var(--season-*)) selected by the static data-season attribute
  * on the wrapper — no hardcoded hex and no dynamically constructed Tailwind classes.
+ *
+ * Moments that carry an `href` render as a clickable card (whole card is the link)
+ * with a visible "Read the guide" cue, so visitors can jump straight to the full
+ * how-to. Moments without an `href` render as a plain, non-interactive card.
  */
 export default function SeasonalCalendar({
   entries,
@@ -37,6 +42,8 @@ export default function SeasonalCalendar({
     color: 'var(--season-accent-contrast)',
   };
   const spineStyle: CSSProperties = { backgroundColor: 'var(--season-accent)' };
+  // accent-strong keeps the small "Read the guide" cue ≥4.5:1 on the white card (WCAG AA).
+  const linkCueStyle: CSSProperties = { color: 'var(--season-accent-strong)' };
 
   return (
     <section data-season={season} aria-label={heading} className="py-12 md:py-16" style={tintStyle}>
@@ -51,32 +58,71 @@ export default function SeasonalCalendar({
         </div>
 
         <Grid columns={{ default: 1, sm: 2, lg: 3 }} gap="medium">
-          {entries.map((entry) => (
-            <div
-              key={`${entry.date}-${entry.moment}`}
-              className="relative h-full rounded-xl border bg-white p-5 pl-6 shadow-sm"
-              style={cardStyle}
-            >
-              {/* Accent spine — colour-independent of the text content */}
-              <span
-                aria-hidden="true"
-                className="absolute left-0 top-0 h-full w-1.5 rounded-l-xl"
-                style={spineStyle}
-              />
-              <span
-                className="inline-block rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide"
-                style={dateChipStyle}
+          {entries.map((entry) => {
+            const cardClassName = 'relative h-full rounded-xl border bg-white p-5 pl-6 shadow-sm';
+
+            const cardContent = (
+              <>
+                {/* Accent spine — colour-independent of the text content */}
+                <span
+                  aria-hidden="true"
+                  className="absolute left-0 top-0 h-full w-1.5 rounded-l-xl"
+                  style={spineStyle}
+                />
+                <span
+                  className="inline-block rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide"
+                  style={dateChipStyle}
+                >
+                  {entry.date}
+                </span>
+                <Heading level={3} className="mt-3 mb-1 text-lg">
+                  {entry.moment}
+                </Heading>
+                <Text color="charcoal" size="sm">
+                  {entry.opportunity}
+                </Text>
+                {entry.href && (
+                  <span
+                    className="mt-3 inline-flex items-center gap-1 text-sm font-semibold"
+                    style={linkCueStyle}
+                  >
+                    Read the guide
+                    <span
+                      aria-hidden="true"
+                      className="transition-transform group-hover:translate-x-0.5"
+                    >
+                      →
+                    </span>
+                  </span>
+                )}
+              </>
+            );
+
+            // Moments with a guide become a whole-card link; the rest stay plain.
+            if (entry.href) {
+              return (
+                <Link
+                  key={`${entry.date}-${entry.moment}`}
+                  href={entry.href}
+                  aria-label={`${entry.moment} — read the full guide`}
+                  className={`group block ${cardClassName} transition-shadow hover:shadow-md`}
+                  style={cardStyle}
+                >
+                  {cardContent}
+                </Link>
+              );
+            }
+
+            return (
+              <div
+                key={`${entry.date}-${entry.moment}`}
+                className={cardClassName}
+                style={cardStyle}
               >
-                {entry.date}
-              </span>
-              <Heading level={3} className="mt-3 mb-1 text-lg">
-                {entry.moment}
-              </Heading>
-              <Text color="charcoal" size="sm">
-                {entry.opportunity}
-              </Text>
-            </div>
-          ))}
+                {cardContent}
+              </div>
+            );
+          })}
         </Grid>
 
         {season === 'autumn' && (

--- a/src/lib/seasonal-hubs.ts
+++ b/src/lib/seasonal-hubs.ts
@@ -4,6 +4,12 @@ export interface SeasonalCalendarEntry {
   date: string; // e.g. "Fri 23–Sat 24 Oct"
   moment: string; // e.g. "Champagne Weekend"
   opportunity: string; // e.g. "Fizz by the glass, a sparkling tasting"
+  /**
+   * Optional path to the in-depth guide for this moment. When present, the
+   * SeasonalCalendar renders the card as a link through to the full how-to.
+   * Omit for moments that don't (yet) have a dedicated guide.
+   */
+  href?: string;
 }
 
 export interface SeasonalHub {
@@ -32,61 +38,73 @@ export const SEASON_HUBS: SeasonalHub[] = [
         date: '17–27 Sep',
         moment: 'Cask Ale Week',
         opportunity: 'Beer of the day, cask passport, meet-the-brewer',
+        href: '/licensees-guide/cask-ale-week-pub-guide',
       },
       {
         date: '19 Sep–4 Oct',
         moment: 'Oktoberfest',
         opportunity: 'Steins, pretzels and an Oompah night of your own',
+        href: '/licensees-guide/oktoberfest-pub-guide',
       },
       {
         date: 'Fri 25 Sep',
         moment: 'Macmillan Coffee Morning',
         opportunity: 'A quiet daytime filled, and a good cause',
+        href: '/licensees-guide/macmillan-coffee-morning-pub-guide',
       },
       {
         date: 'All October',
         moment: 'Sober October',
         opportunity: 'A proper low/no range that earns its place',
+        href: '/licensees-guide/sober-october-low-no-alcohol-pubs',
       },
       {
         date: 'Sun 4 Oct',
         moment: 'National Vodka Day',
         opportunity: 'A cocktail special, a Bloody Mary brunch',
+        href: '/licensees-guide/national-drinks-days-pub-guide',
       },
       {
         date: 'Mon 19 Oct',
         moment: 'Gin & Tonic Day',
         opportunity: 'A G&T board, a local gin spotlight',
+        href: '/licensees-guide/national-drinks-days-pub-guide',
       },
       {
         date: 'Fri 23–Sat 24 Oct',
         moment: 'Champagne Weekend',
         opportunity: 'Fizz by the glass, a sparkling tasting',
+        href: '/licensees-guide/national-drinks-days-pub-guide',
       },
       {
         date: 'Sat 31 Oct',
         moment: 'Halloween',
         opportunity: 'Family by day, fancy dress by night',
+        href: '/licensees-guide/pub-halloween-bonfire-night-events',
       },
       {
         date: 'Thu 5 Nov',
         moment: 'Bonfire Night',
         opportunity: 'Hot drinks, comfort food, the warm-up',
+        href: '/licensees-guide/pub-halloween-bonfire-night-events',
       },
       {
         date: '6–21 Nov',
         moment: 'Autumn rugby',
         opportunity: 'Big-screen bookings, match platters',
+        href: '/licensees-guide/autumn-rugby-nations-championship-pubs',
       },
       {
         date: 'Fri 27–Sun 29 Nov',
         moment: 'Rugby finals weekend (Twickenham)',
         opportunity: 'A full weekend of bookable rugby',
+        href: '/licensees-guide/autumn-rugby-nations-championship-pubs',
       },
       {
         date: 'Fri 27 Nov',
         moment: 'Black Friday',
         opportunity: 'Gift cards, deposits, bounce-back vouchers',
+        href: '/licensees-guide/black-friday-pub-ideas',
       },
       {
         date: 'Mon 30 Nov',
@@ -118,6 +136,7 @@ export const SEASON_HUBS: SeasonalHub[] = [
         date: 'Fri 27 Nov',
         moment: 'Black Friday',
         opportunity: 'Gift cards, party deposits, a December bounce-back voucher',
+        href: '/licensees-guide/black-friday-pub-ideas',
       },
       {
         date: 'Mon 30 Nov',
@@ -128,11 +147,13 @@ export const SEASON_HUBS: SeasonalHub[] = [
         date: 'All December',
         moment: 'Christmas party season',
         opportunity: 'Set menus, pre-orders, deposits — the diary fills early',
+        href: '/licensees-guide/pub-christmas-bookings-fill-december',
       },
       {
         date: 'Fri 25 Dec',
         moment: 'Christmas Day',
         opportunity: 'A booked-only lunch, or a well-earned rest with deposits banked',
+        href: '/licensees-guide/christmas-pub-promotion-ideas',
       },
       {
         date: 'Sat 26 Dec',
@@ -143,6 +164,7 @@ export const SEASON_HUBS: SeasonalHub[] = [
         date: 'Thu 31 Dec',
         moment: "New Year's Eve",
         opportunity: 'A ticketed night with a deposit, not a quiet free-for-all',
+        href: '/licensees-guide/pub-new-years-eve-planning-guide',
       },
       {
         date: 'Fri 1 Jan',


### PR DESCRIPTION
## What changed

Ships the `feat/autumn-toolkit-2026` branch to `main`: the **Autumn** and **Christmas** seasonal hub playbooks (config-driven `SEASON_HUBS`), the supporting season guides (Cask Ale Week, Oktoberfest, Macmillan, national drinks days, rugby, Black Friday and more), the themed hub hero + "at a glance" calendar, homepage/nav/footer playbook surfacing, content tagging (seasons + occasions), UI alignment to the `max-w-4xl` content standard, WCAG AA fixes for the calendar date chips, and SEO/keyword refinements.

The final commit on the branch (this session) makes the **"at a glance" calendar dates clickable**: each dated moment that has a corresponding guide renders as a whole-card link with an always-visible "Read the guide →" cue, a hover shadow-lift and the standard keyboard focus outline. Autumn wires up 12 moments, Christmas 4; moments without a guide stay plain, non-interactive cards.

## Why

Turns the seasonal hubs into a navigable hub-and-spoke: visitors can jump straight from a key date to the full how-to, improving internal linking and the autumn/Christmas toolkit journey.

## Testing done

- [x] `npm run build` — clean (all hub + blog routes prerender)
- [x] `npm run type-check` — clean
- [x] `eslint` on changed files — clean
- [x] Live render check (dev server): autumn 12/12 links + cues, Christmas 4/4 links + cues; dates with no corresponding guide (e.g. St Andrew's Day, Boxing Day, Burns Night) correctly left non-clickable

## Complexity score

S — the final calendar-link change is 2 files (additive optional `href`). The branch as a whole is the larger autumn toolkit feature.

## Breaking changes

None — the new `href` on `SeasonalCalendarEntry` is optional; cards without it render exactly as before.

## Migration risk

None — content/UI only; no schema or data migrations.

## Deployment note

Merging this deploys to production via Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
